### PR TITLE
docs: añadir CHANGELOG de presentaciones (Sprint 1)

### DIFF
--- a/docs/presentations/CHANGELOG-Presentation_19-02.md
+++ b/docs/presentations/CHANGELOG-Presentation_19-02.md
@@ -1,0 +1,22 @@
+# Changelog – Presentation and Script Sprint 1
+
+This document records all the changes made to the project’s presentation and script.
+
+## 📎 Work Links
+
+- [Google Presentation](https://docs.google.com/presentation/d/1879ffBxxbyuBkee5FUyjVRpwYkJI1oe0wTQoyDTfJoE/edit?usp=sharing)
+
+//TODO: Mover la carpeta presentations a carpeta Sprint 1 cuando se cree 
+## 📝 Change Log
+
+### 14/02/2026  
+**Author**: Guillermo Linares Borrego ([Glinbor10](https://github.com/Glinbor10)), Manuel Orta Pérez ([manortper1](https://github.com/manortper1))
+- Diseño de fondo, inicio e índice de presentación para todas las de Street Ask.
+
+### 14/02/2026  
+**Author**: Guillermo Linares Borrego ([Glinbor10](https://github.com/Glinbor10))
+- Estructura básica del contenido de la presentación en el índice de la presentación.
+
+
+  
+


### PR DESCRIPTION
Crea `docs/presentations/CHANGELOG-Presentation_19-02.md` con el registro de cambios de la presentación. Incluye entradas del 14/02/2026 y un TODO para mover la carpeta `presentations` a `Sprint 1`.