### PR TITLE
fix: correct answer timestamps across time zones

### DIFF
--- a/src/main/java/com/streetask/app/answer/AnswerService.java
+++ b/src/main/java/com/streetask/app/answer/AnswerService.java
@@ -1,6 +1,8 @@
 package com.streetask.app.answer;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 import org.springframework.beans.BeanUtils;
@@ -163,7 +165,7 @@ public class AnswerService {
 
 	private void applyDefaults(Answer answer) {
 		if (answer.getCreatedAt() == null) {
-			answer.setCreatedAt(LocalDateTime.now());
+			answer.setCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
 		}
 		if (answer.getIsVerified() == null) {
 			answer.setIsVerified(false);

--- a/src/main/java/com/streetask/app/model/Answer.java
+++ b/src/main/java/com/streetask/app/model/Answer.java
@@ -1,6 +1,7 @@
 package com.streetask.app.model;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
@@ -35,14 +36,14 @@ public class Answer extends BaseEntity {
 
     private Boolean isVerified;
 
-    private LocalDateTime verifiedAt;
+    private OffsetDateTime verifiedAt;
 
     private Integer coinsEarned;
 
     @Embedded
     private GeoPoint userLocation;
 
-    private LocalDateTime createdAt;
+    private OffsetDateTime createdAt;
 
     private Integer upvotes;
 


### PR DESCRIPTION
Update answer timestamp handling to avoid incorrect elapsed time values when reloading the question thread. Replace LocalDateTime with OffsetDateTime for answer creation and verification timestamps and store createdAt in UTC so the API returns a timezone-aware value.