### PR TITLE
feat: add specific coming soon feedback for location search #248

### DIFF
--- a/frontend/src/features/home/ui/HomeScreen.js
+++ b/frontend/src/features/home/ui/HomeScreen.js
@@ -19,6 +19,7 @@ export default function HomeScreen({ navigation }) {
     const [questions, setQuestions] = useState([]);
     const [showQuestions, setShowQuestions] = useState(true);
     const [comingSoon, setComingSoon] = useState(false);
+    const [modalType, setModalType] = useState('notifications');
 
     const isFocused = useIsFocused();
     const latestRequestRef = useRef(0);
@@ -67,10 +68,14 @@ export default function HomeScreen({ navigation }) {
                     </View>
 
                     <View style={styles.topBarRight}>
-                        <TouchableOpacity style={styles.iconBtn} activeOpacity={0.7}>
+                        <TouchableOpacity
+                            style={styles.iconBtn}
+                            activeOpacity={0.7}
+                            onPress={() => { setModalType('search'); setComingSoon(true); }}
+                        >
                             <Ionicons name="search-outline" size={20} color="#374151" />
                         </TouchableOpacity>
-                        <TouchableOpacity style={styles.iconBtn} activeOpacity={0.7} onPress={() => setComingSoon(true)}>
+                        <TouchableOpacity style={styles.iconBtn} activeOpacity={0.7} onPress={() => { setModalType('notifications'); setComingSoon(true); }}>
                             <Ionicons name="notifications-outline" size={20} color="#374151" />
                             {ephemeralNotification ? <View style={styles.badge} /> : null}
                         </TouchableOpacity>
@@ -125,7 +130,6 @@ export default function HomeScreen({ navigation }) {
                 </TouchableOpacity>
             </View>
 
-            {/* ─── Coming Soon Modal ─── */}
             <Modal
                 visible={comingSoon}
                 transparent
@@ -134,10 +138,25 @@ export default function HomeScreen({ navigation }) {
             >
                 <Pressable style={styles.modalOverlay} onPress={() => setComingSoon(false)}>
                     <View style={styles.modalBox}>
-                        <Ionicons name="notifications" size={28} color="#667eea" />
+                        <Ionicons
+                            name={modalType === 'search' ? 'search' : 'notifications'}
+                            size={28}
+                            color="#667eea"
+                        />
+
                         <Text style={styles.modalTitle}>Coming Soon</Text>
-                        <Text style={styles.modalMsg}>Notifications are not available yet.</Text>
-                        <TouchableOpacity style={styles.modalBtn} onPress={() => setComingSoon(false)} activeOpacity={0.8}>
+
+                        <Text style={styles.modalMsg}>
+                            {modalType === 'search'
+                                ? 'Search is not available yet.'
+                                : 'Notifications are not available yet.'}
+                        </Text>
+
+                        <TouchableOpacity
+                            style={styles.modalBtn}
+                            onPress={() => setComingSoon(false)}
+                            activeOpacity={0.8}
+                        >
                             <Text style={styles.modalBtnText}>OK</Text>
                         </TouchableOpacity>
                     </View>


### PR DESCRIPTION
This PR addresses issue #248 by implementing a "Coming Soon" feedback mechanism for the location search feature. Previously, clicking the search icon resulted in no user feedback.

I have refactored the existing comingSoon modal logic to be dynamic and reusable. The application now distinguishes between search and notifications feedback, showing specific icons and messages for each, while maintaining smooth animations during closing transitions.

✅ Changes
Dynamic State Management: Refactored the modal state to track the specific feature type (search or notifications).

Reusable Modal: Modified the existing Modal component in HomeScreen.js to display context-specific icons and text.

Improved UX: Fixed a flickering issue during the closing animation by separating the visibility state from the content type state.

Search Integration: Added the onPress trigger to the search button in the TopBar.