### PR TITLE
fix: add validation on question location and general light validation in backend

### DIFF
--- a/src/main/java/com/streetask/app/model/Answer.java
+++ b/src/main/java/com/streetask/app/model/Answer.java
@@ -13,6 +13,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,21 +35,26 @@ public class Answer extends BaseEntity {
     @JsonBackReference("user-answers")
     private RegularUser user;
 
+    @NotBlank(message = "Answer content is required")
     private String content;
 
     private Boolean isVerified;
 
     private OffsetDateTime verifiedAt;
 
+    @PositiveOrZero(message = "Coins earned must be zero or positive")
     private Integer coinsEarned;
 
     @Embedded
+    @Valid
     private GeoPoint userLocation;
 
     private OffsetDateTime createdAt;
 
+    @PositiveOrZero(message = "Upvotes must be zero or positive")
     private Integer upvotes;
 
+    @PositiveOrZero(message = "Downvotes must be zero or positive")
     private Integer downvotes;
 
     @OneToMany(mappedBy = "answer")

--- a/src/main/java/com/streetask/app/model/Event.java
+++ b/src/main/java/com/streetask/app/model/Event.java
@@ -12,6 +12,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -25,13 +28,16 @@ public class Event extends BaseEntity {
     @JoinColumn(name = "creator_id")
     private BusinessAccount creator;
 
+    @NotBlank(message = "Event title is required")
     private String title;
 
+    @NotBlank(message = "Event description is required")
     private String description;
 
     private EventCategory category;
 
     @Embedded
+    @Valid
     private GeoPoint location;
 
     private String address;
@@ -42,6 +48,7 @@ public class Event extends BaseEntity {
 
     private Boolean featured;
 
+    @PositiveOrZero(message = "Attendee count must be zero or positive")
     private Integer attendeeCount;
 
     private Boolean active;

--- a/src/main/java/com/streetask/app/model/GeoPoint.java
+++ b/src/main/java/com/streetask/app/model/GeoPoint.java
@@ -1,6 +1,9 @@
 package com.streetask.app.model;
 
 import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,7 +12,13 @@ import lombok.Setter;
 @Setter
 public class GeoPoint {
 
+    @NotNull(message = "Latitude is required")
+    @DecimalMin(value = "-90.0", message = "Latitude must be between -90 and 90")
+    @DecimalMax(value = "90.0", message = "Latitude must be between -90 and 90")
     private Double latitude;
 
+    @NotNull(message = "Longitude is required")
+    @DecimalMin(value = "-180.0", message = "Longitude must be between -180 and 180")
+    @DecimalMax(value = "180.0", message = "Longitude must be between -180 and 180")
     private Double longitude;
 }

--- a/src/main/java/com/streetask/app/model/Question.java
+++ b/src/main/java/com/streetask/app/model/Question.java
@@ -14,7 +14,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,13 +34,14 @@ public class Question extends BaseEntity {
     @JoinColumn(name = "event_id")
     private Event event;
 
-    @NotBlank
+    @NotBlank(message = "Question title is required")
     private String title;
 
-    @NotBlank
+    @NotBlank(message = "Question content is required")
     private String content;
 
     @Embedded
+    @Valid
     private GeoPoint location;
 
     private Float radiusKm;
@@ -51,6 +54,7 @@ public class Question extends BaseEntity {
     @JsonDeserialize(using = FlexibleLocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
+    @PositiveOrZero(message = "Answer count must be zero or positive")
     private Integer answerCount;
 
     @OneToMany(mappedBy = "question")

--- a/src/main/java/com/streetask/app/model/UserLocation.java
+++ b/src/main/java/com/streetask/app/model/UserLocation.java
@@ -4,6 +4,9 @@ import com.streetask.app.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,11 +34,17 @@ public class UserLocation extends BaseEntity {
     /**
      * Latitud de la ubicación
      */
+    @NotNull(message = "Latitude is required")
+    @DecimalMin(value = "-90.0", message = "Latitude must be between -90 and 90")
+    @DecimalMax(value = "90.0", message = "Latitude must be between -90 and 90")
     private Double latitude;
 
     /**
      * Longitud de la ubicación
      */
+    @NotNull(message = "Longitude is required")
+    @DecimalMin(value = "-180.0", message = "Longitude must be between -180 and 180")
+    @DecimalMax(value = "180.0", message = "Longitude must be between -180 and 180")
     private Double longitude;
 
     /**

--- a/src/test/java/com/streetask/app/question/QuestionRestControllerTest.java
+++ b/src/test/java/com/streetask/app/question/QuestionRestControllerTest.java
@@ -334,4 +334,156 @@ class QuestionRestControllerTest {
 		return payload;
 	}
 
+	// =============== LOCATION VALIDATION TESTS ===============
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldAcceptValidCoordinates() throws Exception {
+		Map<String, Object> validLocation = new HashMap<>();
+		validLocation.put("latitude", 40.416775);
+		validLocation.put("longitude", -3.703790);
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", validLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.location.latitude").value(40.416775))
+				.andExpect(jsonPath("$.location.longitude").value(-3.703790));
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldRejectInvalidLatitudeTooHigh() throws Exception {
+		Map<String, Object> invalidLocation = new HashMap<>();
+		invalidLocation.put("latitude", 91.0); // Invalid: exceeds max
+		invalidLocation.put("longitude", 0.0);
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", invalidLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldRejectInvalidLatitudeTooLow() throws Exception {
+		Map<String, Object> invalidLocation = new HashMap<>();
+		invalidLocation.put("latitude", -91.0); // Invalid: below min
+		invalidLocation.put("longitude", 0.0);
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", invalidLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldRejectInvalidLongitudeTooHigh() throws Exception {
+		Map<String, Object> invalidLocation = new HashMap<>();
+		invalidLocation.put("latitude", 0.0);
+		invalidLocation.put("longitude", 181.0); // Invalid: exceeds max
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", invalidLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldRejectInvalidLongitudeTooLow() throws Exception {
+		Map<String, Object> invalidLocation = new HashMap<>();
+		invalidLocation.put("latitude", 0.0);
+		invalidLocation.put("longitude", -181.0); // Invalid: below min
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", invalidLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldRejectLocationWithNullLatitude() throws Exception {
+		Map<String, Object> invalidLocation = new HashMap<>();
+		invalidLocation.put("latitude", null);
+		invalidLocation.put("longitude", 0.0);
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", invalidLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldRejectLocationWithNullLongitude() throws Exception {
+		Map<String, Object> invalidLocation = new HashMap<>();
+		invalidLocation.put("latitude", 0.0);
+		invalidLocation.put("longitude", null);
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", invalidLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldAcceptBoundaryValues() throws Exception {
+		Map<String, Object> boundaryLocation = new HashMap<>();
+		boundaryLocation.put("latitude", 90.0); // Max valid
+		boundaryLocation.put("longitude", 180.0); // Max valid
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", boundaryLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.location.latitude").value(90.0))
+				.andExpect(jsonPath("$.location.longitude").value(180.0));
+	}
+
+	@Test
+	@WithMockUser(username = "testcreator@streetask.com")
+	void create_shouldAcceptNegativeBoundaryValues() throws Exception {
+		Map<String, Object> boundaryLocation = new HashMap<>();
+		boundaryLocation.put("latitude", -90.0); // Min valid
+		boundaryLocation.put("longitude", -180.0); // Min valid
+
+		Map<String, Object> questionPayload = createValidQuestionPayload();
+		questionPayload.put("location", boundaryLocation);
+
+		mockMvc.perform(post("/api/v1/questions")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(questionPayload)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.location.latitude").value(-90.0))
+				.andExpect(jsonPath("$.location.longitude").value(-180.0));
+	}
+
 }


### PR DESCRIPTION
Closes #272 

Add bean validation for GeoPoint latitude/longitude ranges, enable nested validation in question-related models, and add controller tests for valid/invalid coordinate payloads so bad location data returns 400 instead of crashing persistence.