### PR TITLE
feat: implement unit test for answer service

### DIFF
--- a/src/test/java/com/streetask/app/answer/AnswerServiceTest.java
+++ b/src/test/java/com/streetask/app/answer/AnswerServiceTest.java
@@ -4,20 +4,23 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.context.ApplicationEventPublisher;
 
+import com.streetask.app.exceptions.ResourceNotFoundException;
+import com.streetask.app.functionalities.notifications.events.AnswerCreatedEvent;
 import com.streetask.app.model.Answer;
 import com.streetask.app.model.GeoPoint;
 import com.streetask.app.model.Question;
-import com.streetask.app.user.RegularUser;
 
 class AnswerServiceTest {
 
@@ -81,6 +84,10 @@ class AnswerServiceTest {
         assertEquals(0, savedAnswer.getDownvotes());
 
         verify(answerRepository, times(1)).save(answer);
+
+        ArgumentCaptor<AnswerCreatedEvent> eventCaptor = ArgumentCaptor.forClass(AnswerCreatedEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+        assertEquals(answerId, eventCaptor.getValue().answerId());
     }
 
     @Test
@@ -89,13 +96,12 @@ class AnswerServiceTest {
         answer.getUserLocation().setLatitude(37.8044); // About 3.2 km away
         answer.getUserLocation().setLongitude(-122.2712);
 
-        when(answerRepository.save(answer)).thenReturn(answer);
-
         assertThrows(IllegalArgumentException.class, () -> {
             answerService.saveAnswer(answer, question);
         });
 
         verify(answerRepository, never()).save(answer);
+        verifyNoInteractions(eventPublisher);
     }
 
     @Test
@@ -107,6 +113,63 @@ class AnswerServiceTest {
         });
 
         verify(answerRepository, never()).save(answer);
+        verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void testSaveAnswerWhenQuestionHasNoLocation() {
+        answer.setUserLocation(null);
+        question.setLocation(null);
+
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer savedAnswer = answerService.saveAnswer(answer, question);
+
+        assertNotNull(savedAnswer);
+        verify(answerRepository, times(1)).save(answer);
+        verify(eventPublisher, times(1)).publishEvent(any(AnswerCreatedEvent.class));
+    }
+
+    @Test
+    void testSaveAnswerWhenQuestionHasNullRadius() {
+        answer.setUserLocation(null);
+        question.setRadiusKm(null);
+
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer savedAnswer = answerService.saveAnswer(answer, question);
+
+        assertNotNull(savedAnswer);
+        verify(answerRepository, times(1)).save(answer);
+        verify(eventPublisher, times(1)).publishEvent(any(AnswerCreatedEvent.class));
+    }
+
+    @Test
+    void testSaveAnswerWhenQuestionHasZeroRadius() {
+        answer.setUserLocation(null);
+        question.setRadiusKm(0f);
+
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer savedAnswer = answerService.saveAnswer(answer, question);
+
+        assertNotNull(savedAnswer);
+        verify(answerRepository, times(1)).save(answer);
+        verify(eventPublisher, times(1)).publishEvent(any(AnswerCreatedEvent.class));
+    }
+
+    @Test
+    void testSaveAnswerWhenQuestionHasNegativeRadius() {
+        answer.setUserLocation(null);
+        question.setRadiusKm(-2f);
+
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer savedAnswer = answerService.saveAnswer(answer, question);
+
+        assertNotNull(savedAnswer);
+        verify(answerRepository, times(1)).save(answer);
+        verify(eventPublisher, times(1)).publishEvent(any(AnswerCreatedEvent.class));
     }
 
     @Test
@@ -124,11 +187,100 @@ class AnswerServiceTest {
     void testFindAnswerByIdNotFound() {
         when(answerRepository.findById(answerId)).thenReturn(Optional.empty());
 
-        assertThrows(Exception.class, () -> {
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> {
             answerService.findAnswer(answerId);
         });
 
+        assertTrue(exception.getMessage().contains("Answer not found with id"));
         verify(answerRepository, times(1)).findById(answerId);
+    }
+
+    @Test
+    void testFindAllDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findAll()).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findAll();
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testFindByQuestionDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findByQuestionId(questionId)).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findByQuestion(questionId);
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findByQuestionId(questionId);
+    }
+
+    @Test
+    void testFindByUserDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findByUserId(userId)).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findByUser(userId);
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void testFindByIsVerifiedDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findByIsVerified(true)).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findByIsVerified(true);
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findByIsVerified(true);
+    }
+
+    @Test
+    void testFindByUserAndIsVerifiedDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findByUserIdAndIsVerified(userId, true)).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findByUserAndIsVerified(userId, true);
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findByUserIdAndIsVerified(userId, true);
+    }
+
+    @Test
+    void testFindByQuestionAndIsVerifiedDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findByQuestionIdAndIsVerified(questionId, true)).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findByQuestionAndIsVerified(questionId, true);
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findByQuestionIdAndIsVerified(questionId, true);
+    }
+
+    @Test
+    void testFindByQuestionAndUserDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findByQuestionIdAndUserId(questionId, userId)).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findByQuestionAndUser(questionId, userId);
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findByQuestionIdAndUserId(questionId, userId);
+    }
+
+    @Test
+    void testFindByQuestionAndUserAndIsVerifiedDelegatesToRepository() {
+        List<Answer> answers = List.of(answer);
+        when(answerRepository.findByQuestionIdAndUserIdAndIsVerified(questionId, userId, true)).thenReturn(answers);
+
+        Iterable<Answer> result = answerService.findByQuestionAndUserAndIsVerified(questionId, userId, true);
+
+        assertSame(answers, result);
+        verify(answerRepository, times(1)).findByQuestionIdAndUserIdAndIsVerified(questionId, userId, true);
     }
 
     @Test
@@ -155,7 +307,83 @@ class AnswerServiceTest {
         Answer result = answerService.updateAnswer(updatedAnswer, answerId, question);
 
         assertNotNull(result);
+        assertSame(answer, result);
         assertEquals("Updated Answer", result.getContent());
+        assertEquals(37.7749, result.getUserLocation().getLatitude());
+        assertEquals(-122.4194, result.getUserLocation().getLongitude());
+        verify(answerRepository, times(1)).findById(answerId);
         verify(answerRepository, times(1)).save(answer);
+    }
+
+    @Test
+    void testUpdateVotesIncrementsUpvotes() {
+        answer.setUpvotes(2);
+        answer.setDownvotes(3);
+
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer result = answerService.updateVotes(answerId, 1, 0);
+
+        assertEquals(3, result.getUpvotes());
+        assertEquals(3, result.getDownvotes());
+        verify(answerRepository, times(1)).save(answer);
+    }
+
+    @Test
+    void testUpdateVotesIncrementsDownvotes() {
+        answer.setUpvotes(2);
+        answer.setDownvotes(3);
+
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer result = answerService.updateVotes(answerId, 0, 1);
+
+        assertEquals(2, result.getUpvotes());
+        assertEquals(4, result.getDownvotes());
+        verify(answerRepository, times(1)).save(answer);
+    }
+
+    @Test
+    void testUpdateVotesPreventsNegativeUpvotes() {
+        answer.setUpvotes(1);
+        answer.setDownvotes(2);
+
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer result = answerService.updateVotes(answerId, -5, 0);
+
+        assertEquals(0, result.getUpvotes());
+        assertEquals(2, result.getDownvotes());
+        verify(answerRepository, times(1)).save(answer);
+    }
+
+    @Test
+    void testUpdateVotesPreventsNegativeDownvotes() {
+        answer.setUpvotes(3);
+        answer.setDownvotes(1);
+
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer result = answerService.updateVotes(answerId, 0, -5);
+
+        assertEquals(3, result.getUpvotes());
+        assertEquals(0, result.getDownvotes());
+        verify(answerRepository, times(1)).save(answer);
+    }
+
+    @Test
+    void testUpdateVotesNotFound() {
+        when(answerRepository.findById(answerId)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> answerService.updateVotes(answerId, 1, 1));
+
+        assertTrue(exception.getMessage().contains("Answer not found with id"));
+        verify(answerRepository, times(1)).findById(answerId);
+        verify(answerRepository, never()).save(any(Answer.class));
     }
 }


### PR DESCRIPTION
Expanded AnswerServiceTest to cover missing AnswerService logic and edge cases.

Added:

- Event publishing assertion after successful saveAnswer (AnswerCreatedEvent).
- saveAnswer edge cases: no question location, null radius, zero radius, and negative radius.
- Full query delegation coverage for all findBy... methods.
- updateVotes coverage: increments, non-negative clamping, and not-found path.
- Stronger updateAnswer assertions and minor test cleanup.