### PR TITLE
fix: resolve null message in answer notifications

### DIFF
--- a/src/main/java/com/streetask/app/functionalities/notifications/observers/AnswerActivityNotificationObserver.java
+++ b/src/main/java/com/streetask/app/functionalities/notifications/observers/AnswerActivityNotificationObserver.java
@@ -60,7 +60,7 @@ public class AnswerActivityNotificationObserver {
         FrontendNotificationMessage payload = FrontendNotificationMessage.builder()
                 .type("ANSWER_TO_QUESTION")
                 .title("New activity on a followed question")
-                .message(actorName + " answered: " + question.getTitle())
+                .message(actorName + " answered: " + answer.getContent())
                 .referenceId(question.getId())
                 .referenceType("QUESTION")
                 .timestamp(LocalDateTime.now())


### PR DESCRIPTION
Use the answer content as the main notification text.