### PR TITLE
fix: metrics workflow tuesday implementation

### DIFF
--- a/.github/workflows/agile-metrics.yml
+++ b/.github/workflows/agile-metrics.yml
@@ -2,13 +2,8 @@ name: Agile Metrics Report
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - trunk
-    types:
-      - closed
   schedule:
-    - cron: '0 12 * * 2'
+    - cron: '0 13 * * 2'
 
 permissions:
   contents: write
@@ -17,7 +12,6 @@ permissions:
 
 jobs:
   generate-agile-metrics:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This workflow used to works every PR to trunk but it doesnt anymore. Now it runs every Tuesay at 13:00