### PR TITLE
feat: add unit and integration tests for edit profile

### DIFF
--- a/src/main/java/com/streetask/app/user/UserRestController.java
+++ b/src/main/java/com/streetask/app/user/UserRestController.java
@@ -15,18 +15,13 @@
  */
 package com.streetask.app.user;
 
-import java.util.UUID;
-import java.util.Map;
 import java.util.List;
-
-import jakarta.validation.Valid;
+import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import com.streetask.app.auth.payload.response.MessageResponse;
-import com.streetask.app.exceptions.AccessDeniedException;
-import com.streetask.app.util.RestPreconditions;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +33,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.streetask.app.auth.payload.response.MessageResponse;
+import com.streetask.app.exceptions.AccessDeniedException;
+import com.streetask.app.util.RestPreconditions;
+
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -106,6 +106,14 @@ class UserRestController {
 	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<User> update(@PathVariable("userId") UUID id, @RequestBody @Valid User user) {
 		RestPreconditions.checkNotNull(userService.findUser(id), "User", "ID", id);
+
+		User currentUser = userService.findCurrentUser();
+		boolean isAdmin = currentUser.hasAuthority("ADMIN");
+		boolean isOwner = currentUser.getId().equals(id);
+
+		if (!isAdmin && !isOwner) {
+			throw new AccessDeniedException("You don't have permission to edit this profile.");
+		}
 		return new ResponseEntity<>(this.userService.updateUser(user, id), HttpStatus.OK);
 	}
 

--- a/src/main/java/com/streetask/app/user/UserService.java
+++ b/src/main/java/com/streetask/app/user/UserService.java
@@ -7,20 +7,21 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.StreamSupport;
 
-import jakarta.validation.Valid;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
-import com.streetask.app.answer.AnswerRepository;
-import com.streetask.app.exceptions.ResourceNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.streetask.app.question.QuestionRepository;
+
+import com.streetask.app.answer.AnswerRepository;
+import com.streetask.app.exceptions.ResourceNotFoundException;
 import com.streetask.app.model.Question;
+import com.streetask.app.question.QuestionRepository;
+
+import jakarta.validation.Valid;
 
 @Service
 public class UserService {
@@ -96,7 +97,7 @@ public class UserService {
 
 		String previousPassword = toUpdate.getPassword();
 
-		BeanUtils.copyProperties(user, toUpdate, "id");
+		BeanUtils.copyProperties(user, toUpdate, "id", "authority", "accountType", "createdAt", "lastLogin", "active");
 
 		if (user.getPassword() == null || user.getPassword().isBlank()) {
 			toUpdate.setPassword(previousPassword);
@@ -159,7 +160,6 @@ public class UserService {
 
 		long questionsCount = questionRepository.countByCreatorId(userId);
 		long answersCount = answerRepository.countByUserId(userId);
-
 
 		// Aggregate likes (upvotes) and dislikes (downvotes) for all answers by this
 		// user

--- a/src/test/java/com/streetask/app/user/UserRestControllerIntegrationTest.java
+++ b/src/test/java/com/streetask/app/user/UserRestControllerIntegrationTest.java
@@ -37,241 +37,317 @@ import com.streetask.app.model.Question;
 @AutoConfigureMockMvc
 class UserRestControllerIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    @MockBean
-    private UserService userService;
+        @MockBean
+        private UserService userService;
 
-    @MockBean
-    private AuthoritiesService authService;
+        @MockBean
+        private AuthoritiesService authService;
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void findAll_shouldReturnAllUsersForAdmin() throws Exception {
-        User firstUser = createUser(UUID.randomUUID(), "first@example.com", "first", "USER");
-        User secondUser = createUser(UUID.randomUUID(), "second@example.com", "second", "ADMIN");
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void findAll_shouldReturnAllUsersForAdmin() throws Exception {
+                User firstUser = createUser(UUID.randomUUID(), "first@example.com", "first", "USER");
+                User secondUser = createUser(UUID.randomUUID(), "second@example.com", "second", "ADMIN");
 
-        when(userService.findAll()).thenReturn(List.of(firstUser, secondUser));
+                when(userService.findAll()).thenReturn(List.of(firstUser, secondUser));
 
-        mockMvc.perform(get("/api/v1/users"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].email").value("first@example.com"))
-                .andExpect(jsonPath("$[1].userName").value("second"));
-    }
+                mockMvc.perform(get("/api/v1/users"))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].email").value("first@example.com"))
+                                .andExpect(jsonPath("$[1].userName").value("second"));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void findAll_withAuthParam_shouldReturnFilteredUsersForAdmin() throws Exception {
-        User regularUser = createUser(UUID.randomUUID(), "user@example.com", "user", "USER");
-        when(userService.findAllByAuthority("USER")).thenReturn(List.of(regularUser));
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void findAll_withAuthParam_shouldReturnFilteredUsersForAdmin() throws Exception {
+                User regularUser = createUser(UUID.randomUUID(), "user@example.com", "user", "USER");
+                when(userService.findAllByAuthority("USER")).thenReturn(List.of(regularUser));
 
-        mockMvc.perform(get("/api/v1/users").param("auth", "USER"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
-                .andExpect(jsonPath("$[0].authority.authority").value("USER"));
-    }
+                mockMvc.perform(get("/api/v1/users").param("auth", "USER"))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+                                .andExpect(jsonPath("$[0].authority.authority").value("USER"));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void findAllAuthorities_shouldReturnAuthoritiesForAdmin() throws Exception {
-        Authorities admin = new Authorities();
-        admin.setId(UUID.randomUUID());
-        admin.setAuthority("ADMIN");
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void findAllAuthorities_shouldReturnAuthoritiesForAdmin() throws Exception {
+                Authorities admin = new Authorities();
+                admin.setId(UUID.randomUUID());
+                admin.setAuthority("ADMIN");
 
-        Authorities user = new Authorities();
-        user.setId(UUID.randomUUID());
-        user.setAuthority("USER");
+                Authorities user = new Authorities();
+                user.setId(UUID.randomUUID());
+                user.setAuthority("USER");
 
-        when(authService.findAll()).thenReturn(List.of(admin, user));
+                when(authService.findAll()).thenReturn(List.of(admin, user));
 
-        mockMvc.perform(get("/api/v1/users/authorities"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].authority").value("ADMIN"))
-                .andExpect(jsonPath("$[1].authority").value("USER"));
-    }
+                mockMvc.perform(get("/api/v1/users/authorities"))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].authority").value("ADMIN"))
+                                .andExpect(jsonPath("$[1].authority").value("USER"));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void findById_shouldReturnUserForAdmin() throws Exception {
-        UUID userId = UUID.randomUUID();
-        User user = createUser(userId, "detail@example.com", "detail", "USER");
-        when(userService.findUser(userId)).thenReturn(user);
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void findById_shouldReturnUserForAdmin() throws Exception {
+                UUID userId = UUID.randomUUID();
+                User user = createUser(userId, "detail@example.com", "detail", "USER");
+                when(userService.findUser(userId)).thenReturn(user);
 
-        mockMvc.perform(get("/api/v1/users/{id}", userId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(userId.toString()))
-                .andExpect(jsonPath("$.email").value("detail@example.com"));
-    }
+                mockMvc.perform(get("/api/v1/users/{id}", userId))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.id").value(userId.toString()))
+                                .andExpect(jsonPath("$.email").value("detail@example.com"));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void create_shouldPersistUserForAdmin() throws Exception {
-        User payload = createUser(null, "created@example.com", "created", "USER");
-        User savedUser = createUser(UUID.randomUUID(), "created@example.com", "created", "USER");
-        when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void create_shouldPersistUserForAdmin() throws Exception {
+                User payload = createUser(null, "created@example.com", "created", "USER");
+                User savedUser = createUser(UUID.randomUUID(), "created@example.com", "created", "USER");
+                when(userService.saveUser(any(User.class))).thenReturn(savedUser);
 
-        mockMvc.perform(post("/api/v1/users")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(payload)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(savedUser.getId().toString()))
-                .andExpect(jsonPath("$.userName").value("created"));
-    }
+                mockMvc.perform(post("/api/v1/users")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(payload)))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.id").value(savedUser.getId().toString()))
+                                .andExpect(jsonPath("$.userName").value("created"));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void update_shouldUpdateUserForAdmin() throws Exception {
-        UUID userId = UUID.randomUUID();
-        User existingUser = createUser(userId, "before@example.com", "before", "USER");
-        User payload = createUser(null, "after@example.com", "after", "USER");
-        User updatedUser = createUser(userId, "after@example.com", "after", "USER");
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void update_shouldUpdateUserForAdmin() throws Exception {
+                UUID userId = UUID.randomUUID();
+                User existingUser = createUser(userId, "before@example.com", "before", "USER");
+                User payload = createUser(null, "after@example.com", "after", "USER");
+                User updatedUser = createUser(userId, "after@example.com", "after", "USER");
 
-        when(userService.findUser(userId)).thenReturn(existingUser);
-        when(userService.updateUser(any(User.class), eq(userId))).thenReturn(updatedUser);
+                User adminUser = createUser(UUID.randomUUID(), "admin@example.com", "admin", "ADMIN");
+                when(userService.findCurrentUser()).thenReturn(adminUser);
 
-        mockMvc.perform(put("/api/v1/users/{userId}", userId)
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(payload)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value("after@example.com"))
-                .andExpect(jsonPath("$.userName").value("after"));
-    }
+                when(userService.findUser(userId)).thenReturn(existingUser);
+                when(userService.updateUser(any(User.class), eq(userId))).thenReturn(updatedUser);
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void delete_shouldDeleteOtherUserForAdmin() throws Exception {
-        UUID targetUserId = UUID.randomUUID();
-        UUID currentUserId = UUID.randomUUID();
+                mockMvc.perform(put("/api/v1/users/{userId}", userId)
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(payload)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.email").value("after@example.com"))
+                                .andExpect(jsonPath("$.userName").value("after"));
+        }
 
-        when(userService.findUser(targetUserId))
-                .thenReturn(createUser(targetUserId, "target@example.com", "target", "USER"));
-        when(userService.findCurrentUser())
-                .thenReturn(createUser(currentUserId, "admin@example.com", "admin", "ADMIN"));
+        @Test
+        @WithMockUser(username = "owner@example.com", authorities = { "USER" })
+        void update_shouldUpdateOwnProfileSuccessfully() throws Exception {
+                UUID userId = UUID.randomUUID();
+                User currentUser = createUser(userId, "owner@example.com", "owner", "USER");
+                User payload = createUser(null, "updated@example.com", "updated", "USER");
+                User updatedUser = createUser(userId, "updated@example.com", "updated", "USER");
 
-        mockMvc.perform(delete("/api/v1/users/{userId}", targetUserId))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(new MessageResponse("User deleted!"))));
+                when(userService.findCurrentUser()).thenReturn(currentUser);
+                when(userService.findUser(userId)).thenReturn(currentUser);
+                when(userService.updateUser(any(User.class), eq(userId))).thenReturn(updatedUser);
 
-        verify(userService).deleteUser(targetUserId);
-    }
+                mockMvc.perform(put("/api/v1/users/{userId}", userId)
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(payload)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.email").value("updated@example.com"))
+                                .andExpect(jsonPath("$.userName").value("updated"));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "ADMIN" })
-    void delete_whenDeletingSelf_shouldReturnForbidden() throws Exception {
-        UUID currentUserId = UUID.randomUUID();
-        User currentUser = createUser(currentUserId, "admin@example.com", "admin", "ADMIN");
+        @Test
+        @WithMockUser(username = "owner@example.com", authorities = { "USER" })
+        void update_withInvalidPayload_shouldReturnBadRequest() throws Exception {
+                UUID userId = UUID.randomUUID();
 
-        when(userService.findUser(currentUserId)).thenReturn(currentUser);
-        when(userService.findCurrentUser()).thenReturn(currentUser);
+                User invalidPayload = new User();
+                invalidPayload.setEmail("");
+                invalidPayload.setUserName("");
+                invalidPayload.setFirstName("");
+                invalidPayload.setLastName("");
 
-        mockMvc.perform(delete("/api/v1/users/{userId}", currentUserId))
-                .andExpect(status().isForbidden());
+                mockMvc.perform(put("/api/v1/users/{userId}", userId)
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(invalidPayload)))
+                                .andExpect(status().isBadRequest());
 
-        verify(userService, never()).deleteUser(currentUserId);
-    }
+                verify(userService, never()).updateUser(any(User.class), eq(userId));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "USER" })
-    void statsEndpoint_shouldReturnStatsForAuthenticatedUser() throws Exception {
-        UUID userId = UUID.randomUUID();
-        when(userService.findUser(userId)).thenReturn(createUser(userId, "stats@example.com", "stats", "USER"));
-        when(userService.getUserStats(userId)).thenReturn(Map.of(
-                "questionsCount", 2,
-                "answersCount", 5,
-                "username", "stats",
-                "role", "USER",
-                "likesCount", 7,
-                "dislikesCount", 1,
-                "reputation", 13));
+        @Test
+        @WithMockUser(username = "hacker@example.com", authorities = { "USER" })
+        void update_whenEditingOtherProfile_shouldReturnForbidden() throws Exception {
+                UUID targetUserId = UUID.randomUUID();
+                UUID hackerId = UUID.randomUUID();
 
-        mockMvc.perform(get("/api/v1/users/{id}/stats", userId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.username").value("stats"))
-                .andExpect(jsonPath("$.reputation").value(13));
-    }
+                User hackerUser = createUser(hackerId, "hacker@example.com", "hacker", "USER");
+                User targetUser = createUser(targetUserId, "target@example.com", "target", "USER");
+                User payload = createUser(null, "hacked@example.com", "hacked", "USER");
 
-    @Test
-    @WithMockUser(authorities = { "USER" })
-    void statsEndpoint_whenUserDoesNotExist_shouldReturnNotFound() throws Exception {
-        UUID userId = UUID.randomUUID();
-        when(userService.findUser(userId)).thenThrow(new ResourceNotFoundException("User", "ID", userId));
+                when(userService.findCurrentUser()).thenReturn(hackerUser);
+                when(userService.findUser(targetUserId)).thenReturn(targetUser);
 
-        mockMvc.perform(get("/api/v1/users/{id}/stats", userId))
-                .andExpect(status().isNotFound());
+                mockMvc.perform(put("/api/v1/users/{userId}", targetUserId)
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(payload)))
+                                .andExpect(status().isForbidden());
 
-        verify(userService, never()).getUserStats(userId);
-    }
+                verify(userService, never()).updateUser(any(User.class), eq(targetUserId));
+        }
 
-    @Test
-    @WithMockUser(authorities = { "USER" })
-    void getUserQuestions_shouldReturnQuestionsForAuthenticatedUser() throws Exception {
-        UUID userId = UUID.randomUUID();
-        Question question = new Question();
-        question.setId(UUID.randomUUID());
-        question.setTitle("How does this work?");
-        question.setContent("Question content");
+        @Test // No authentication provided
+        void update_whenUnauthenticated_shouldReturnUnauthorized() throws Exception {
+                UUID userId = UUID.randomUUID();
+                User payload = createUser(null, "updated@example.com", "updated", "USER");
 
-        when(userService.findUser(userId)).thenReturn(createUser(userId, "owner@example.com", "owner", "USER"));
-        when(userService.findQuestionsByUserId(userId)).thenReturn(List.of(question));
+                mockMvc.perform(put("/api/v1/users/{userId}", userId)
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(payload)))
+                                .andExpect(status().isUnauthorized());
+        }
 
-        mockMvc.perform(get("/api/v1/users/{id}/questions", userId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].title").value("How does this work?"));
-    }
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void delete_shouldDeleteOtherUserForAdmin() throws Exception {
+                UUID targetUserId = UUID.randomUUID();
+                UUID currentUserId = UUID.randomUUID();
 
-    @Test
-    @WithMockUser(authorities = { "USER" })
-    void getUserAnswers_shouldReturnAnswersForAuthenticatedUser() throws Exception {
-        UUID userId = UUID.randomUUID();
-        Answer answer = new Answer();
-        answer.setId(UUID.randomUUID());
-        answer.setContent("This is an answer");
+                when(userService.findUser(targetUserId))
+                                .thenReturn(createUser(targetUserId, "target@example.com", "target", "USER"));
+                when(userService.findCurrentUser())
+                                .thenReturn(createUser(currentUserId, "admin@example.com", "admin", "ADMIN"));
 
-        when(userService.findUser(userId)).thenReturn(createUser(userId, "owner@example.com", "owner", "USER"));
-        when(userService.findAnswersByUserId(userId)).thenReturn(List.of(answer));
+                mockMvc.perform(delete("/api/v1/users/{userId}", targetUserId))
+                                .andExpect(status().isOk())
+                                .andExpect(content().json(
+                                                objectMapper.writeValueAsString(new MessageResponse("User deleted!"))));
 
-        mockMvc.perform(get("/api/v1/users/{id}/answers", userId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].content").value("This is an answer"));
-    }
+                verify(userService).deleteUser(targetUserId);
+        }
 
-    @Test
-    void statsEndpoint_whenUnauthenticated_shouldReturnUnauthorized() throws Exception {
-        mockMvc.perform(get("/api/v1/users/{id}/stats", UUID.randomUUID()))
-                .andExpect(status().isUnauthorized());
-    }
+        @Test
+        @WithMockUser(authorities = { "ADMIN" })
+        void delete_whenDeletingSelf_shouldReturnForbidden() throws Exception {
+                UUID currentUserId = UUID.randomUUID();
+                User currentUser = createUser(currentUserId, "admin@example.com", "admin", "ADMIN");
 
-    @Test
-    @WithMockUser(authorities = { "USER" })
-    void adminOnlyEndpoints_shouldRemainForbiddenForRegularUsers() throws Exception {
-        mockMvc.perform(get("/api/v1/users"))
-                .andExpect(status().isForbidden());
+                when(userService.findUser(currentUserId)).thenReturn(currentUser);
+                when(userService.findCurrentUser()).thenReturn(currentUser);
 
-        mockMvc.perform(post("/api/v1/users")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(createUser(null, "created@example.com", "created", "USER"))))
-                .andExpect(status().isForbidden());
-    }
+                mockMvc.perform(delete("/api/v1/users/{userId}", currentUserId))
+                                .andExpect(status().isForbidden());
 
-    private User createUser(UUID id, String email, String userName, String authorityName) {
-        User user = new User();
-        user.setId(id);
-        user.setEmail(email);
-        user.setUserName(userName);
-        user.setFirstName("Test");
-        user.setLastName("User");
-        user.setPassword("password123");
-        user.setActive(true);
-        user.setCreatedAt(LocalDateTime.now());
+                verify(userService, never()).deleteUser(currentUserId);
+        }
 
-        Authorities authority = new Authorities();
-        authority.setId(UUID.randomUUID());
-        authority.setAuthority(authorityName);
-        user.setAuthority(authority);
-        return user;
-    }
+        @Test
+        @WithMockUser(authorities = { "USER" })
+        void statsEndpoint_shouldReturnStatsForAuthenticatedUser() throws Exception {
+                UUID userId = UUID.randomUUID();
+                when(userService.findUser(userId)).thenReturn(createUser(userId, "stats@example.com", "stats", "USER"));
+                when(userService.getUserStats(userId)).thenReturn(Map.of(
+                                "questionsCount", 2,
+                                "answersCount", 5,
+                                "username", "stats",
+                                "role", "USER",
+                                "likesCount", 7,
+                                "dislikesCount", 1,
+                                "reputation", 13));
+
+                mockMvc.perform(get("/api/v1/users/{id}/stats", userId))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.username").value("stats"))
+                                .andExpect(jsonPath("$.reputation").value(13));
+        }
+
+        @Test
+        @WithMockUser(authorities = { "USER" })
+        void statsEndpoint_whenUserDoesNotExist_shouldReturnNotFound() throws Exception {
+                UUID userId = UUID.randomUUID();
+                when(userService.findUser(userId)).thenThrow(new ResourceNotFoundException("User", "ID", userId));
+
+                mockMvc.perform(get("/api/v1/users/{id}/stats", userId))
+                                .andExpect(status().isNotFound());
+
+                verify(userService, never()).getUserStats(userId);
+        }
+
+        @Test
+        @WithMockUser(authorities = { "USER" })
+        void getUserQuestions_shouldReturnQuestionsForAuthenticatedUser() throws Exception {
+                UUID userId = UUID.randomUUID();
+                Question question = new Question();
+                question.setId(UUID.randomUUID());
+                question.setTitle("How does this work?");
+                question.setContent("Question content");
+
+                when(userService.findUser(userId)).thenReturn(createUser(userId, "owner@example.com", "owner", "USER"));
+                when(userService.findQuestionsByUserId(userId)).thenReturn(List.of(question));
+
+                mockMvc.perform(get("/api/v1/users/{id}/questions", userId))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].title").value("How does this work?"));
+        }
+
+        @Test
+        @WithMockUser(authorities = { "USER" })
+        void getUserAnswers_shouldReturnAnswersForAuthenticatedUser() throws Exception {
+                UUID userId = UUID.randomUUID();
+                Answer answer = new Answer();
+                answer.setId(UUID.randomUUID());
+                answer.setContent("This is an answer");
+
+                when(userService.findUser(userId)).thenReturn(createUser(userId, "owner@example.com", "owner", "USER"));
+                when(userService.findAnswersByUserId(userId)).thenReturn(List.of(answer));
+
+                mockMvc.perform(get("/api/v1/users/{id}/answers", userId))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].content").value("This is an answer"));
+        }
+
+        @Test
+        void statsEndpoint_whenUnauthenticated_shouldReturnUnauthorized() throws Exception {
+                mockMvc.perform(get("/api/v1/users/{id}/stats", UUID.randomUUID()))
+                                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser(authorities = { "USER" })
+        void adminOnlyEndpoints_shouldRemainForbiddenForRegularUsers() throws Exception {
+                mockMvc.perform(get("/api/v1/users"))
+                                .andExpect(status().isForbidden());
+
+                mockMvc.perform(post("/api/v1/users")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                createUser(null, "created@example.com", "created", "USER"))))
+                                .andExpect(status().isForbidden());
+        }
+
+        private User createUser(UUID id, String email, String userName, String authorityName) {
+                User user = new User();
+                user.setId(id);
+                user.setEmail(email);
+                user.setUserName(userName);
+                user.setFirstName("Test");
+                user.setLastName("User");
+                user.setPassword("password123");
+                user.setActive(true);
+                user.setCreatedAt(LocalDateTime.now());
+
+                Authorities authority = new Authorities();
+                authority.setId(UUID.randomUUID());
+                authority.setAuthority(authorityName);
+                user.setAuthority(authority);
+                return user;
+        }
 }

--- a/src/test/java/com/streetask/app/user/UserServiceTest.java
+++ b/src/test/java/com/streetask/app/user/UserServiceTest.java
@@ -1,33 +1,47 @@
 package com.streetask.app.user;
 
-import com.streetask.app.answer.AnswerRepository;
-import com.streetask.app.exceptions.ResourceNotFoundException;
-import com.streetask.app.question.QuestionRepository;
-import com.streetask.app.model.Question;
-import com.streetask.app.model.Answer;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import com.streetask.app.answer.AnswerRepository;
+import com.streetask.app.exceptions.ResourceNotFoundException;
+import com.streetask.app.model.Answer;
+import com.streetask.app.model.Question;
+import com.streetask.app.question.QuestionRepository;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserService Unit Tests")
@@ -239,6 +253,92 @@ class UserServiceTest {
         User updated = userService.updateUser(update, testUserId);
 
         assertEquals(testUserId, updated.getId());
+    }
+
+    @Test
+    void updateUser_shouldUpdateEditableFieldsAndKeepOldPassword() {
+        User originalUser = createTestUser(UUID.randomUUID(), "old@example.com", "olduser");
+        originalUser.setPassword("old_encoded_password");
+
+        User incomingUpdate = new User();
+        incomingUpdate.setFirstName("NewFirst");
+        incomingUpdate.setLastName("NewLast");
+        incomingUpdate.setUserName("newuser");
+        incomingUpdate.setEmail("new@example.com");
+        incomingUpdate.setPassword("");
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(originalUser));
+        when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        User updatedUser = userService.updateUser(incomingUpdate, testUserId);
+
+        assertEquals("NewFirst", updatedUser.getFirstName());
+        assertEquals("NewLast", updatedUser.getLastName());
+        assertEquals("newuser", updatedUser.getUserName());
+        assertEquals("new@example.com", updatedUser.getEmail());
+
+        assertEquals("old_encoded_password", updatedUser.getPassword());
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+
+    @Test
+    @DisplayName("updateUser should encode password when a new one is provided")
+    void updateUser_shouldEncodePasswordWhenProvided() {
+        User originalUser = createTestUser(UUID.randomUUID(), "old@example.com", "olduser");
+
+        User incomingUpdate = new User();
+        incomingUpdate.setFirstName("NewFirst");
+        incomingUpdate.setLastName("NewLast");
+        incomingUpdate.setUserName("newuser");
+        incomingUpdate.setEmail("new@example.com");
+        incomingUpdate.setPassword("new_raw_password");
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(originalUser));
+        when(passwordEncoder.encode("new_raw_password")).thenReturn("new_encoded_password");
+        when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        User updatedUser = userService.updateUser(incomingUpdate, testUserId);
+
+        assertEquals("new_encoded_password", updatedUser.getPassword());
+        verify(passwordEncoder).encode("new_raw_password");
+    }
+
+    @Test
+    @DisplayName("updateUser should NOT modify protected fields (authorities, active, createdAt, id)")
+    void updateUser_shouldNotModifyProtectedFields() {
+        LocalDateTime oldDate = LocalDateTime.of(2020, 1, 1, 0, 0);
+        Authorities oldAuth = new Authorities();
+        oldAuth.setAuthority("USER");
+
+        User originalUser = createTestUser(testUserId, "old@example.com", "olduser");
+        originalUser.setCreatedAt(oldDate);
+        originalUser.setAuthority(oldAuth);
+        originalUser.setActive(true);
+
+        User maliciousUpdate = new User();
+        maliciousUpdate.setFirstName("Hacker");
+        maliciousUpdate.setLastName("Man");
+        maliciousUpdate.setUserName("hacker");
+        maliciousUpdate.setEmail("hacker@mail.com");
+
+        maliciousUpdate.setId(UUID.randomUUID());
+        Authorities adminAuth = new Authorities();
+        adminAuth.setAuthority("ADMIN");
+        maliciousUpdate.setAuthority(adminAuth);
+        maliciousUpdate.setActive(false);
+        maliciousUpdate.setCreatedAt(LocalDateTime.now());
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(originalUser));
+        when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        User updatedUser = userService.updateUser(maliciousUpdate, testUserId);
+
+        assertEquals("Hacker", updatedUser.getFirstName(), "Editable fields should update");
+
+        assertEquals(testUserId, updatedUser.getId(), "ID should not be modified");
+        assertEquals("USER", updatedUser.getAuthority().getAuthority(), "Authority should not be modified");
+        assertTrue(updatedUser.getActive(), "Active status should not be modified");
+        assertEquals(oldDate, updatedUser.getCreatedAt(), "Creation date should not be modified");
     }
 
     // ================= DELETE =================


### PR DESCRIPTION
[FEATURE]: Add tests for Edit profile feature #293

I have implemented the required unit and integration tests for UserService and UserRestController to ensure that personal data is updated correctly and that the API returns the expected error codes (400, 403, 404) for invalid or unauthorized requests.

Most importantly, while developing these tests, I detected and patched two critical security vulnerabilities in the codebase. The first allowed any user to modify protected internal fields (such as their role or reputation) simply by sending them in the JSON payload. The second allowed a logged-in user to modify someone else's profile. Both security issues have been fixed in the controller and the service, and the new tests guarantee that the behavior is now strict and secure.

Finally, I have verified that all new and existing test suites are passing successfully.