### PR TITLE
Update MySQL config for local development and add premium user seed data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,16 +11,16 @@ services:
     image: mysql:8.0
     container_name: streetask-db
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpassword}
-      MYSQL_DATABASE: ${MYSQL_DATABASE:-streetask}
-      MYSQL_USER: ${MYSQL_USER:-streetask}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-streetask}
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: streetask
+      MYSQL_USER: streetask
+      MYSQL_PASSWORD: streetask
     ports:
       - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD:-rootpassword}"]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpassword" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -39,13 +39,12 @@ services:
       - .:/app
       - maven_cache:/root/.m2
     environment:
-      #SPRING_PROFILES_ACTIVE: default
-      # For MySQL, uncomment these and comment out the line above:
       SPRING_PROFILES_ACTIVE: mysql
-      MYSQL_URL: jdbc:mysql://db:3306/${MYSQL_DATABASE:-streetask}?useSSL=false&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&serverTimezone=UTC
-      MYSQL_USER: ${MYSQL_USER:-streetask}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-streetask}
-    depends_on:  # Uncomment when using MySQL
+      MYSQL_URL: jdbc:mysql://db:3306/streetask?useSSL=false&allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&serverTimezone=UTC
+      MYSQL_USER: streetask
+      MYSQL_PASSWORD: streetask
+    depends_on:
+      # Uncomment when using MySQL
       db:
         condition: service_healthy
     restart: unless-stopped

--- a/src/main/resources/data-mysql.sql
+++ b/src/main/resources/data-mysql.sql
@@ -72,3 +72,48 @@ ON DUPLICATE KEY UPDATE
     visibility_radius_km = VALUES(visibility_radius_km),
     phone = VALUES(phone),
     profile_photo = VALUES(profile_photo);
+
+-- Premium regular user: premium1@streetask.com / password: 4dm1n
+INSERT INTO appusers (id, email, user_name, password, first_name, last_name, authority, account_type, active, created_at)
+VALUES (
+    UUID_TO_BIN('cccccccc-cccc-cccc-cccc-cccccccccccc'),
+    'premium1@streetask.com',
+    'premium1',
+    '$2a$10$nMmTWAhPTqXqLDJTag3prumFrAJpsYtroxf0ojesFYq0k4PmcbWUS',
+    'Premium',
+    'User',
+    UUID_TO_BIN('22222222-2222-2222-2222-222222222222'),
+    'REGULAR_USER',
+    TRUE,
+    CURRENT_TIMESTAMP
+)
+ON DUPLICATE KEY UPDATE
+    email = VALUES(email),
+    user_name = VALUES(user_name),
+    password = VALUES(password),
+    first_name = VALUES(first_name),
+    last_name = VALUES(last_name),
+    authority = VALUES(authority),
+    account_type = VALUES(account_type),
+    active = VALUES(active);
+
+-- RegularUser profile for premium1 (premium_active = TRUE)
+INSERT INTO regular_users (id, coin_balance, rating, verified, visibility_radius_km, phone, profile_photo, premium_active)
+VALUES (
+    UUID_TO_BIN('cccccccc-cccc-cccc-cccc-cccccccccccc'),
+    0,
+    0,
+    FALSE,
+    10,
+    '987654321',
+    NULL,
+    TRUE
+)
+ON DUPLICATE KEY UPDATE
+    coin_balance = VALUES(coin_balance),
+    rating = VALUES(rating),
+    verified = VALUES(verified),
+    visibility_radius_km = VALUES(visibility_radius_km),
+    phone = VALUES(phone),
+    profile_photo = VALUES(profile_photo),
+    premium_active = VALUES(premium_active);


### PR DESCRIPTION
This pull request makes several important changes to the Docker Compose configuration and the MySQL seed data. The main focus is on simplifying environment variable usage in `docker-compose.yml` and adding a premium user to the database initialization script.

Configuration simplification:

* Replaced environment variable references with static values for MySQL credentials and database in the `db` service section of `docker-compose.yml`, making the configuration more straightforward and predictable.
* Updated the `MYSQL_URL`, `MYSQL_USER`, and `MYSQL_PASSWORD` environment variables in the `app` service section of `docker-compose.yml` to use static values instead of environment variables, reducing complexity and potential errors.

Database initialization:

* Added a new premium regular user (`premium1@streetask.com`) and corresponding profile with `premium_active = TRUE` in `src/main/resources/data-mysql.sql`, ensuring that the application has a sample premium user for testing or demonstration purposes.

<img width="1823" height="527" alt="image" src="https://github.com/user-attachments/assets/2574d4b9-6cbf-4b3f-9b1b-8367a3375fc6" />
