### PR TITLE
fix: fix profile answers and unify English UI labels

### DIFF
--- a/frontend/src/features/answers/ui/QuestionThreadScreen.js
+++ b/frontend/src/features/answers/ui/QuestionThreadScreen.js
@@ -645,7 +645,7 @@ export default function QuestionThreadScreen({ route, navigation }) {
                                             color={questionReported ? '#9ca3af' : '#b91c1c'}
                                         />
                                         <Text style={[styles.questionReportText, questionReported && styles.questionReportTextDisabled]}>
-                                            {questionReported ? 'Reportado' : 'Reportar'}
+                                            {questionReported ? 'Reported' : 'Report'}
                                         </Text>
                                     </TouchableOpacity>
                                 </View>

--- a/frontend/src/features/home/ui/components/MapComponent.js
+++ b/frontend/src/features/home/ui/components/MapComponent.js
@@ -312,17 +312,17 @@ export default function MapComponent({ questions = [], onQuestionPress, onLocati
                                             />
                                         </div>
                                         <span style={{ color: canAnswer ? '#ea580c' : '#6b7280', fontWeight: 700 }}>
-                                            {canAnswer ? 'Puedes responder' : 'Fuera de tu radio'}
+                                            {canAnswer ? 'You can answer' : 'Out of your range'}
                                         </span>
                                         <br />
                                         {Number.isFinite(radiusKm) && radiusKm > 0 && (
                                             <>
                                                 <span style={{ opacity: 0.85 }}>
-                                                    Radio respuesta: {radiusKm.toFixed(2)} km
+                                                    Answer radius: {radiusKm.toFixed(2)} km
                                                 </span>
                                                 <br />
                                                 <span style={{ opacity: 0.85 }}>
-                                                    Tu distancia: {distanceKm.toFixed(2)} km
+                                                    Your distance: {distanceKm.toFixed(2)} km
                                                 </span>
                                                 <br />
                                             </>

--- a/frontend/src/features/profile/ProfileStats.js
+++ b/frontend/src/features/profile/ProfileStats.js
@@ -76,7 +76,9 @@ export default function ProfileStats() {
             <View style={styles.historyText}>
                 <Text style={styles.itemTitle} numberOfLines={2}>
                     {type === 'questions' ? 'Q: ' : 'A: '}
-                    {item.text || item.title || "No content"}
+                    {type === 'answers'
+                        ? (item.content || item.text || item.title || "No content")
+                        : (item.title || item.text || item.content || "No content")}
                 </Text>
                 <Text style={styles.itemDate}>
                     {item.createdAt ? new Date(item.createdAt).toLocaleDateString() : 'Unknown date'}

--- a/frontend/src/features/questions/ui/CreateQuestionScreen.js
+++ b/frontend/src/features/questions/ui/CreateQuestionScreen.js
@@ -850,11 +850,11 @@ const styles = StyleSheet.create({
   },
   mapOkBtn: {
     flex: 1,
-    backgroundColor: '#667eea',
+    backgroundColor: '#a52019',
     borderRadius: 14,
     paddingVertical: 14,
     alignItems: 'center',
-    shadowColor: '#667eea',
+    shadowColor: '#a52019',
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 12,


### PR DESCRIPTION
This pull request primarily focuses on improving the user interface by updating text to English for consistency and clarity, refining the display logic for profile statistics, and adjusting UI styling for better visual coherence. The most important changes are grouped below:

**Localization and Text Updates:**

* Changed various UI strings from Spanish to English in `QuestionThreadScreen.js` (e.g., "Reportado" to "Reported", "Reportar" to "Report") for consistency across the app.
* Updated map-related user messages in `MapComponent.js` to English (e.g., "Puedes responder" to "You can answer", "Fuera de tu radio" to "Out of your range", and related radius/distance labels).

**Profile Stats Display Logic:**

* Improved the logic for displaying question and answer content in `ProfileStats.js` to prioritize the most relevant available fields for each type (answers now show `content` first, questions show `title` first).

**UI Styling Adjustments:**

* Changed the color scheme for the map confirmation button in `CreateQuestionScreen.js` from blue/purple (`#667eea`) to red (`#a52019`) for a more consistent look and feel.- Show answer content correctly in profile history.
- Translate report/map texts from Spanish to English.
- Match map Confirm button color with Post Question.