### PR TITLE
feat: add tax ID validation and error handling in signup process

### DIFF
--- a/frontend/src/features/auth/ui/BusinessSignupScreen.js
+++ b/frontend/src/features/auth/ui/BusinessSignupScreen.js
@@ -19,13 +19,33 @@ export default function BusinessSignupScreen({ navigation, route }) {
 	const [website, setWebsite] = useState('');
 	const [description, setDescription] = useState('');
 	const [error, setError] = useState('');
+	const [taxIdError, setTaxIdError] = useState('');
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [focusedField, setFocusedField] = useState(null);
 
+	// Tax ID format validation: 1 letter + 7 digits + 1 alphanumeric character
+	const TAX_ID_REGEX = /^[A-Za-z]\d{7}[A-Za-z0-9]$/;
+
+	const handleTaxIdChange = (text) => {
+		const upper = text.toUpperCase();
+		setTaxId(upper);
+		// Provide real-time feedback on tax ID format
+		if (upper.length > 0 && !TAX_ID_REGEX.test(upper)) {
+			setTaxIdError('Format: 1 letter + 7 digits + 1 character (e.g., A1234567B)');
+		} else {
+			setTaxIdError('');
+		}
+	};
+
 	const handleProceedToPayment = async () => {
 		setError('');
+		setTaxIdError('');
 		if (!taxId.trim()) { setError('Tax ID is required.'); return; }
 		if (!companyName.trim()) { setError('Company Name is required.'); return; }
+		if (!TAX_ID_REGEX.test(taxId)) {
+			setError('Tax ID must be: 1 letter + 7 digits + 1 control character (e.g., A1234567B).');
+			return;
+		}
 
 		try {
 			setIsSubmitting(true);
@@ -116,7 +136,8 @@ export default function BusinessSignupScreen({ navigation, route }) {
 					<Text style={styles.subtitle}>Complete your business profile</Text>
 
 					{/* Fields */}
-					{renderInput('Tax ID *', taxId, setTaxId, 'tax', { icon: 'pricetag-outline', autoCapitalize: 'characters', placeholder: 'A1234567B' })}
+					{renderInput('Tax ID *', taxId, handleTaxIdChange, 'tax', { icon: 'pricetag-outline', autoCapitalize: 'characters', placeholder: 'A1234567B' })}
+					{taxIdError ? <Text style={styles.warningText}>{taxIdError}</Text> : (taxId && TAX_ID_REGEX.test(taxId) ? <Text style={styles.successText}>✓ Valid format</Text> : null)}
 					{renderInput('Company Name *', companyName, setCompanyName, 'company', { icon: 'business-outline', placeholder: 'Acme Inc.' })}
 					{renderInput('Address', address, setAddress, 'addr', { icon: 'location-outline', placeholder: '123 Main St.' })}
 					{renderInput('Website', website, setWebsite, 'web', { icon: 'globe-outline', autoCapitalize: 'none', placeholder: 'https://...' })}
@@ -257,6 +278,18 @@ const styles = StyleSheet.create({
 		fontSize: 13,
 		textAlign: 'center',
 		marginTop: 14,
+	},
+	warningText: {
+		color: '#f59e0b',
+		fontSize: 12,
+		marginTop: 6,
+		marginBottom: 4,
+	},
+	successText: {
+		color: '#10b981',
+		fontSize: 12,
+		marginTop: 6,
+		marginBottom: 4,
 	},
 	benefitsCard: {
 		backgroundColor: '#f9fafb',

--- a/src/main/java/com/streetask/app/auth/AuthController.java
+++ b/src/main/java/com/streetask/app/auth/AuthController.java
@@ -119,11 +119,18 @@ public class AuthController {
 	@PostMapping("/signup/business")
 	public ResponseEntity<MessageResponse> completeBusinessUser(
 			@Valid @RequestBody BusinessSignupRequest signUpRequest) {
+		// Validate email exists and is a basic user
+		if (!userService.existsUser(signUpRequest.getEmail())) {
+			return ResponseEntity.badRequest()
+					.body(new MessageResponse(
+							"Error: Basic user registration not found. Please complete the basic signup first."));
+		}
+
 		String normalizedTaxId = signUpRequest.getTaxId().trim().toUpperCase().replace(" ", "").replace("-", "");
 		signUpRequest.setTaxId(normalizedTaxId);
 
 		// Check whether tax ID already exists
-		if (businessAccountRepository.existsByTaxId(signUpRequest.getTaxId()).equals(true)) {
+		if (businessAccountRepository.existsByTaxId(signUpRequest.getTaxId())) {
 			return ResponseEntity.badRequest().body(new MessageResponse("Error: Tax ID is already registered!"));
 		}
 		// Complete business account data

--- a/src/test/java/com/streetask/app/integration/AuthSignupIntegrationTest.java
+++ b/src/test/java/com/streetask/app/integration/AuthSignupIntegrationTest.java
@@ -28,254 +28,255 @@ import jakarta.transaction.Transactional;
 @Transactional
 class AuthSignupIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    @Autowired
-    private UserRepository userRepository;
+        @Autowired
+        private UserRepository userRepository;
 
-    @Test
-    void signupBasicShouldCreateUserWhenPayloadIsValid() throws Exception {
-        String email = "regular.success@streetask.com";
+        @Test
+        void signupBasicShouldCreateUserWhenPayloadIsValid() throws Exception {
+                String email = "regular.success@streetask.com";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validBasicPayload(email, "regularUser1"))))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message")
-                        .value("Basic user data saved! Complete your registration."));
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validBasicPayload(email, "regularUser1"))))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.message")
+                                                .value("Basic user data saved! Complete your registration."));
 
-        assertThat(userRepository.findByEmail(email)).isPresent();
-    }
+                assertThat(userRepository.findByEmail(email)).isPresent();
+        }
 
-    @Test
-    void signupBasicShouldReturnBadRequestWhenEmailAlreadyExists() throws Exception {
-        String email = "duplicated.email@streetask.com";
+        @Test
+        void signupBasicShouldReturnBadRequestWhenEmailAlreadyExists() throws Exception {
+                String email = "duplicated.email@streetask.com";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validBasicPayload(email, "dupUser1"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validBasicPayload(email, "dupUser1"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validBasicPayload(email, "dupUser2"))))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Error: Email is already registered!"));
-    }
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validBasicPayload(email, "dupUser2"))))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.message").value("Error: Email is already registered!"));
+        }
 
-    @Test
-    void signupBasicShouldReturnBadRequestWhenUserNameAlreadyExists() throws Exception {
-        String duplicatedUserName = "duplicatedUser";
+        @Test
+        void signupBasicShouldReturnBadRequestWhenUserNameAlreadyExists() throws Exception {
+                String duplicatedUserName = "duplicatedUser";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        validBasicPayload("first.user@streetask.com", duplicatedUserName))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                validBasicPayload("first.user@streetask.com", duplicatedUserName))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        validBasicPayload("second.user@streetask.com", duplicatedUserName))))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Error: Username is already taken!"));
-    }
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                validBasicPayload("second.user@streetask.com", duplicatedUserName))))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.message").value("Error: Username is already taken!"));
+        }
 
-    @Test
-    void signupBasicShouldReturnBadRequestWhenRequiredFieldIsMissing() throws Exception {
-        Map<String, Object> invalidPayload = new HashMap<>();
-        invalidPayload.put("email", "invalid.payload@streetask.com");
-        invalidPayload.put("password", "123456");
-        invalidPayload.put("firstName", "Invalid");
-        invalidPayload.put("lastName", "Payload");
+        @Test
+        void signupBasicShouldReturnBadRequestWhenRequiredFieldIsMissing() throws Exception {
+                Map<String, Object> invalidPayload = new HashMap<>();
+                invalidPayload.put("email", "invalid.payload@streetask.com");
+                invalidPayload.put("password", "123456");
+                invalidPayload.put("firstName", "Invalid");
+                invalidPayload.put("lastName", "Payload");
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidPayload)))
-                .andExpect(status().isBadRequest());
-    }
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(invalidPayload)))
+                                .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    void signupRegularShouldConvertBasicUserToRegularUser() throws Exception {
-        String email = "regular.convert@streetask.com";
+        @Test
+        void signupRegularShouldConvertBasicUserToRegularUser() throws Exception {
+                String email = "regular.convert@streetask.com";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper
-                        .writeValueAsString(validBasicPayload(email, "regularConvertUser"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper
+                                                .writeValueAsString(validBasicPayload(email, "regularConvertUser"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/regular")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(Map.of("email", email))))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("Regular user registered successfully!"));
+                mockMvc.perform(post("/api/v1/auth/signup/regular")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(Map.of("email", email))))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.message").value("Regular user registered successfully!"));
 
-        User storedUser = userRepository.findByEmail(email).orElseThrow();
-        assertThat(storedUser).isInstanceOf(RegularUser.class);
-        assertThat(storedUser.getAuthority().getAuthority()).isEqualTo("USER");
-        assertThat(storedUser.getActive()).isTrue();
-    }
+                User storedUser = userRepository.findByEmail(email).orElseThrow();
+                assertThat(storedUser).isInstanceOf(RegularUser.class);
+                assertThat(storedUser.getAuthority().getAuthority()).isEqualTo("USER");
+                assertThat(storedUser.getActive()).isTrue();
+        }
 
-    @Test
-    void signupRegularShouldReturnBadRequestWhenBasicUserDoesNotExist() throws Exception {
-        mockMvc.perform(post("/api/v1/auth/signup/regular")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper
-                        .writeValueAsString(Map.of("email", "missing.user@streetask.com"))))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Error: User not found or already completed!"));
-    }
+        @Test
+        void signupRegularShouldReturnBadRequestWhenBasicUserDoesNotExist() throws Exception {
+                mockMvc.perform(post("/api/v1/auth/signup/regular")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper
+                                                .writeValueAsString(Map.of("email", "missing.user@streetask.com"))))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.message").value("Error: User not found or already completed!"));
+        }
 
-    @Test
-    void signupBusinessShouldConvertBasicUserToBusinessAccount() throws Exception {
-        String email = "business.convert@streetask.com";
-        String taxId = "B12345678";
+        @Test
+        void signupBusinessShouldConvertBasicUserToBusinessAccount() throws Exception {
+                String email = "business.convert@streetask.com";
+                String taxId = "B12345678";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validBasicPayload(email, "businessUser1"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validBasicPayload(email, "businessUser1"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/business")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper
-                        .writeValueAsString(validBusinessPayload(email, taxId, "Gran Via 1"))))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message")
-                        .value("Business account registered successfully! Your account is pending admin verification."));
+                mockMvc.perform(post("/api/v1/auth/signup/business")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper
+                                                .writeValueAsString(validBusinessPayload(email, taxId, "Gran Via 1"))))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.message")
+                                                .value("Business account registered successfully! Your account is pending admin verification."));
 
-        User storedUser = userRepository.findByEmail(email).orElseThrow();
-        assertThat(storedUser).isInstanceOf(BusinessAccount.class);
-        BusinessAccount businessAccount = (BusinessAccount) storedUser;
+                User storedUser = userRepository.findByEmail(email).orElseThrow();
+                assertThat(storedUser).isInstanceOf(BusinessAccount.class);
+                BusinessAccount businessAccount = (BusinessAccount) storedUser;
 
-        assertThat(businessAccount.getTaxId()).isEqualTo(taxId);
-        assertThat(businessAccount.getCompanyName()).isEqualTo("Test Company");
-        assertThat(businessAccount.getAddress()).isEqualTo("Gran Via 1");
-        assertThat(businessAccount.getAuthority().getAuthority()).isEqualTo("BUSINESS");
-        assertThat(businessAccount.getActive()).isFalse();
-    }
+                assertThat(businessAccount.getTaxId()).isEqualTo(taxId);
+                assertThat(businessAccount.getCompanyName()).isEqualTo("Test Company");
+                assertThat(businessAccount.getAddress()).isEqualTo("Gran Via 1");
+                assertThat(businessAccount.getAuthority().getAuthority()).isEqualTo("BUSINESS");
+                assertThat(businessAccount.getActive()).isFalse();
+        }
 
-    @Test
-    void signupBusinessShouldReturnBadRequestWhenTaxIdAlreadyExists() throws Exception {
-        String duplicatedTaxId = "B87654321";
+        @Test
+        void signupBusinessShouldReturnBadRequestWhenTaxIdAlreadyExists() throws Exception {
+                String duplicatedTaxId = "B87654321";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper
-                        .writeValueAsString(validBasicPayload("business.one@streetask.com",
-                                "businessOne"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper
+                                                .writeValueAsString(validBasicPayload("business.one@streetask.com",
+                                                                "businessOne"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/business")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        validBusinessPayload("business.one@streetask.com", duplicatedTaxId,
-                                "Address 1"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/business")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                validBusinessPayload("business.one@streetask.com", duplicatedTaxId,
+                                                                "Address 1"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper
-                        .writeValueAsString(validBasicPayload("business.two@streetask.com",
-                                "businessTwo"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper
+                                                .writeValueAsString(validBasicPayload("business.two@streetask.com",
+                                                                "businessTwo"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/business")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        validBusinessPayload("business.two@streetask.com", duplicatedTaxId,
-                                "Address 2"))))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Error: Tax ID is already registered!"));
-    }
+                mockMvc.perform(post("/api/v1/auth/signup/business")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                validBusinessPayload("business.two@streetask.com", duplicatedTaxId,
+                                                                "Address 2"))))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.message").value("Error: Tax ID is already registered!"));
+        }
 
-    @Test
-    void signupBusinessShouldReturnBadRequestWhenBasicUserDoesNotExist() throws Exception {
-        mockMvc.perform(post("/api/v1/auth/signup/business")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        validBusinessPayload("missing.user@streetask.com", "B99999991",
-                                "Address Missing"))))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Error: User not found or already completed!"));
-    }
+        @Test
+        void signupBusinessShouldReturnBadRequestWhenBasicUserDoesNotExist() throws Exception {
+                mockMvc.perform(post("/api/v1/auth/signup/business")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                validBusinessPayload("missing.user@streetask.com", "B99999991",
+                                                                "Address Missing"))))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.message").value(
+                                                "Error: Basic user registration not found. Please complete the basic signup first."));
+        }
 
-    @Test
-    void signupBusinessShouldReturnBadRequestWhenTaxIdFormatIsInvalid() throws Exception {
-        String email = "business.invalidtaxid@streetask.com";
+        @Test
+        void signupBusinessShouldReturnBadRequestWhenTaxIdFormatIsInvalid() throws Exception {
+                String email = "business.invalidtaxid@streetask.com";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validBasicPayload(email, "invalidTaxUser"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validBasicPayload(email, "invalidTaxUser"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/business")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        validBusinessPayload(email, "12345678A", "Invalid Address"))))
-                .andExpect(status().isBadRequest());
-    }
+                mockMvc.perform(post("/api/v1/auth/signup/business")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                validBusinessPayload(email, "12345678A", "Invalid Address"))))
+                                .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    void signupBusinessShouldReturnBadRequestWhenCompanyNameIsMissing() throws Exception {
-        String email = "business.nocompany@streetask.com";
+        @Test
+        void signupBusinessShouldReturnBadRequestWhenCompanyNameIsMissing() throws Exception {
+                String email = "business.nocompany@streetask.com";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validBasicPayload(email, "noCompanyUser"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validBasicPayload(email, "noCompanyUser"))))
+                                .andExpect(status().isOk());
 
-        Map<String, Object> payload = validBusinessPayload(email, "B12345679", "Address 3");
-        payload.remove("companyName");
+                Map<String, Object> payload = validBusinessPayload(email, "B12345679", "Address 3");
+                payload.remove("companyName");
 
-        mockMvc.perform(post("/api/v1/auth/signup/business")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(payload)))
-                .andExpect(status().isBadRequest());
-    }
+                mockMvc.perform(post("/api/v1/auth/signup/business")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(payload)))
+                                .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    void signupBusinessShouldNormalizeTaxIdToUpperCaseBeforeSaving() throws Exception {
-        String email = "business.normalize@streetask.com";
+        @Test
+        void signupBusinessShouldNormalizeTaxIdToUpperCaseBeforeSaving() throws Exception {
+                String email = "business.normalize@streetask.com";
 
-        mockMvc.perform(post("/api/v1/auth/signup/basic")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validBasicPayload(email, "normalizeUser"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/basic")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validBasicPayload(email, "normalizeUser"))))
+                                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/api/v1/auth/signup/business")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(
-                        validBusinessPayload(email, "b12345670", "Address 4"))))
-                .andExpect(status().isOk());
+                mockMvc.perform(post("/api/v1/auth/signup/business")
+                                .contentType(APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                                validBusinessPayload(email, "b12345670", "Address 4"))))
+                                .andExpect(status().isOk());
 
-        User storedUser = userRepository.findByEmail(email).orElseThrow();
-        assertThat(storedUser).isInstanceOf(BusinessAccount.class);
-        BusinessAccount businessAccount = (BusinessAccount) storedUser;
-        assertThat(businessAccount.getTaxId()).isEqualTo("B12345670");
-    }
+                User storedUser = userRepository.findByEmail(email).orElseThrow();
+                assertThat(storedUser).isInstanceOf(BusinessAccount.class);
+                BusinessAccount businessAccount = (BusinessAccount) storedUser;
+                assertThat(businessAccount.getTaxId()).isEqualTo("B12345670");
+        }
 
-    private Map<String, Object> validBasicPayload(String email, String userName) {
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("email", email);
-        payload.put("userName", userName);
-        payload.put("password", "123456");
-        payload.put("firstName", "Test");
-        payload.put("lastName", "User");
-        return payload;
-    }
+        private Map<String, Object> validBasicPayload(String email, String userName) {
+                Map<String, Object> payload = new HashMap<>();
+                payload.put("email", email);
+                payload.put("userName", userName);
+                payload.put("password", "123456");
+                payload.put("firstName", "Test");
+                payload.put("lastName", "User");
+                return payload;
+        }
 
-    private Map<String, Object> validBusinessPayload(String email, String taxId, String address) {
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("email", email);
-        payload.put("taxId", taxId);
-        payload.put("companyName", "Test Company");
-        payload.put("address", address);
-        return payload;
-    }
+        private Map<String, Object> validBusinessPayload(String email, String taxId, String address) {
+                Map<String, Object> payload = new HashMap<>();
+                payload.put("email", email);
+                payload.put("taxId", taxId);
+                payload.put("companyName", "Test Company");
+                payload.put("address", address);
+                return payload;
+        }
 }


### PR DESCRIPTION
This pull request improves the business signup flow by adding real-time validation and clearer error handling for the Tax ID field in the frontend, and by strengthening backend validation for business user registration. The changes enhance user experience by providing immediate feedback on Tax ID format and ensure that only users who have completed basic signup can proceed with business registration.

**Frontend improvements to Tax ID validation:**

* Added real-time Tax ID format validation using a regex and provided immediate feedback with warning or success messages in `BusinessSignupScreen.js`. The Tax ID must be 1 letter + 7 digits + 1 alphanumeric character (e.g., A1234567B). [[1]](diffhunk://#diff-54300aeebe9a5a5c11a2f8f24469be7f0f84cc6e382bb2a70ee0670e2d352227R22-R48) [[2]](diffhunk://#diff-54300aeebe9a5a5c11a2f8f24469be7f0f84cc6e382bb2a70ee0670e2d352227L119-R140)
* Introduced new styles for warning and success messages related to Tax ID input.

**Backend validation enhancements:**

* Updated `/signup/business` endpoint in `AuthController.java` to check that the user exists as a basic user before allowing business registration, returning a clear error message if not. Also simplified the tax ID existence check.

**Test updates:**

* Adjusted integration test to expect the new error message when a business signup is attempted for a non-existent basic user.