### PR TITLE
docs: update social media planning status

### DIFF
--- a/docs/social-media-planning.md
+++ b/docs/social-media-planning.md
@@ -6,6 +6,6 @@
 | ST-002         | Corrección presentación    | 03/03/2026           | 8:00  | Instagram, tiktok | Publicado   | https://www.instagram.com/p/DVadPnDiC55/?igsh=MWkwMzgyc214dW1nMg== , https://vm.tiktok.com/ZNRuoJUe3/ |
 | ST-003         | ¿Quiénes somos?            | 03/03/2026           | 15:30 | Instagram, tiktok | Publicado   | https://www.instagram.com/p/DVbOx_LiEQw/?igsh=azFpamx3OG1IOWE5 , https://vm.tiktok.com/ZNRuEXo5U/ |
 | ST-004         | Conversaciones             | 04/03/2026           | 15:30 | Instagram, tiktok | Publicado   | https://www.instagram.com/p/DVdwzwjiMCV/?igsh=MWhmengzZ2I2ajRnOQ== , https://vm.tiktok.com/ZNRuEggE8/ |
-| ST-005         | Muestra mockups            | 08/03/2026           | 16:30 | Instagram, tiktok | Programado  | https://www.instagram.com/p/DVoGtzfCK1T/?igsh=MWYxNHUzNTF4aXhrcg== , https://vm.tiktok.com/ZNRuEpHwy/ |
-| ST-006         | Búsqueda usuarios pilotos  | 09/03/2026           | 15:30 | Instagram, tiktok | Programado  | https://www.instagram.com/p/DVrWA9yiJRD/?igsh=a2J2dnh2eWl1c3pr , https://vm.tiktok.com/ZNRuE3L2H/ |
-| ST-007         | Video kill-opener          |                      |       | Instagram, tiktok | Programado  |                 |
+| ST-005         | Muestra mockups            | 08/03/2026           | 16:30 | Instagram, tiktok | Publicado  | https://www.instagram.com/p/DVoGtzfCK1T/?igsh=MWYxNHUzNTF4aXhrcg== , https://vm.tiktok.com/ZNRuEpHwy/ |
+| ST-006         | Búsqueda usuarios pilotos  | 09/03/2026           | 15:30 | Instagram, tiktok | Publicado  | https://www.instagram.com/p/DVrWA9yiJRD/?igsh=a2J2dnh2eWl1c3pr , https://vm.tiktok.com/ZNRuE3L2H/ |
+| ST-007         | Video enseñando la app        |             19/03/2026         |   15:00    | Instagram, tiktok | Publicado  |        https://www.instagram.com/reel/DWEYlEyCOQ_/?igsh=Y3BkcTlrY3IwajR2 , https://vm.tiktok.com/ZNRxGvA79/         |


### PR DESCRIPTION
This pull request updates the social media planning document to reflect the latest publication status of posts and adds a new scheduled post entry. The main changes are:

Social media post status updates:

* Changed the status of `ST-005` ("Muestra mockups") and `ST-006` ("Búsqueda usuarios pilotos") from "Programado" (Scheduled) to "Publicado" (Published), indicating these posts have now been published.

Content additions:

* Updated the `ST-007` entry: replaced the placeholder "Video kill-opener" with a new post, "Video enseñando la app", including its scheduled date, time, and publication status, along with links to the Instagram Reel and TikTok video.