### PR TITLE
docs: add Sprint 3 azure and budgetary alerting details

### DIFF
--- a/docs/Sprint 3/azure-contributors-alerts.md
+++ b/docs/Sprint 3/azure-contributors-alerts.md
@@ -1,0 +1,29 @@
+# Sprint 3: Cloud Infrastructure & Governance
+
+## 🚀 Overview
+For **Sprint 3**, we have activated and configured the **Azure for Students** sponsorship environment. Access has been decentralized to allow all developers to deploy resources independently, ensuring team agility without compromising security or account ownership.
+
+## 💰 Budgetary Constraints & Alerting
+- **Total Subscription Budget:** $85.00 USD.
+- **Reset Period:** Billing Year (Aligned with the University of Seville Sponsorship cycle).
+- **Notification Policy:** Automated emails are sent to all 5 team members (Owner + 4 Contributors) upon reaching specific thresholds.
+
+### 🔔 Configured Alerts Table:
+| Threshold (%) | Alert Type | Amount (USD) | Purpose / Action Required |
+| :--- | :--- | :--- | :--- |
+| **25%** | **Actual** | $21.25 | **Status:** Project kick-off. Initial spending confirmed. |
+| **50%** | **Actual** | $42.50 | **Warning:** Half budget consumed. Review active resources. |
+| **75%** | **Actual** | $63.75 | **Caution:** High consumption. Optimize SKUs and tiers. |
+| **85%** | **Actual** | $72.25 | **Critical:** Approaching limit. Stop non-essential tests. |
+| **90%** | **Actual** | $76.50 | **Freeze Zone:** No new resources allowed without approval. |
+| **95%** | **Forecasted** | $80.75 | **Predictive Shield:** Predictive alert to avoid sudden shutdown. |
+
+## 👥 Access Control (RBAC)
+- **Identity Provider:** University of Seville (US) Tenant.
+- **Role Assigned:** `Contributor` (Full management of resources, no access to billing/ownership).
+- **Team Members:** 
+    - Guillermo Linares
+    - Oscar Gomez
+    - Javier Pallarés
+    - Santia Bregu
+    - Manuel Zoilo Buzon


### PR DESCRIPTION
Closes #479 
This pull request introduces a new documentation file outlining the Azure cloud infrastructure setup and governance for Sprint 3. The document details the activation of the Azure for Students environment, budgetary constraints, alerting policies, and access control measures for the team.

Cloud Infrastructure & Budget Management:

* Added `docs/Sprint 3/azure-contributors-alerts.md` documenting the activation and configuration of the Azure for Students environment, including decentralized access for developers and an $85.00 USD annual budget cap.
* Defined automated budget alerts at multiple consumption thresholds (25%, 50%, 75%, 85%, 90%, and 95%) with clear actions for each stage to ensure proactive cost management.

Access Control & Team Governance:

* Specified role-based access control (RBAC) using the University of Seville tenant as the identity provider, assigning `Contributor` roles to all team members to balance resource management capabilities and security.
* Listed all team members with access, ensuring transparency and traceability in cloud resource management.