### PR TITLE
Feature/admin strike delete

### DIFF
--- a/frontend/src/features/admin/ui/AdminUsersScreen.js
+++ b/frontend/src/features/admin/ui/AdminUsersScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, Alert, ActivityIndicator, TextInput, Modal } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -12,6 +12,10 @@ export default function AdminUsersScreen() {
     const [searchQuery, setSearchQuery] = useState('');
 
     const [modalVisible, setModalVisible] = useState(false);
+    const [strikeModalVisible, setStrikeModalVisible] = useState(false);
+    const [confirmDeleteVisible, setConfirmDeleteVisible] = useState(false);
+    const [userToDelete, setUserToDelete] = useState(null);
+    const [selectedUserForStrike, setSelectedUserForStrike] = useState(null);
     const [editingUser, setEditingUser] = useState(null);
     const [form, setForm] = useState({
         email: '',
@@ -20,33 +24,68 @@ export default function AdminUsersScreen() {
         lastName: '',
         authority: 'USER',
     });
+    const [strikeForm, setStrikeForm] = useState({
+        reason: '',
+        description: '',
+    });
+    const [confirmStrikeVisible, setConfirmStrikeVisible] = useState(false);
+    const [strikeCounts, setStrikeCounts] = useState({});
 
-    useEffect(() => {
-        fetchUsers();
+    const loadStrikeCounts = useCallback(async (usersList) => {
+        const entries = await Promise.all(
+            usersList
+                .filter(user => {
+                    const authority = user.authorities?.[0]?.authority;
+                    return authority !== 'ADMIN' && authority !== 'ROLE_ADMIN';
+                })
+                .map(async (user) => {
+                    try {
+                        const response = await apiClient.get(
+                            `/api/v1/moderation/users/${user.id}/strike-count`
+                        );
+                        return [user.id, response.data?.count ?? 0];
+                    } catch (error) {
+                        return [user.id, 0];
+                    }
+                })
+        );
+        setStrikeCounts(Object.fromEntries(entries));
     }, []);
 
-    const fetchUsers = async () => {
+    const fetchUsers = useCallback(async () => {
         setLoading(true);
         try {
             const response = await apiClient.get('/api/v1/users');
-            if (response.data) {
-                setUsers(response.data);
+
+            let usersData = [];
+            let data = response.data;
+
+            if (typeof data === 'string') {
+                data = JSON.parse(data);
             }
+
+            if (Array.isArray(data)) {
+                usersData = data;
+            } else if (data && typeof data === 'object') {
+                usersData = [];
+            }
+
+            setUsers(usersData);
+            await loadStrikeCounts(usersData);
         } catch (error) {
             console.error("Error fetching users:", error);
             Alert.alert("Error", "Users could not be loaded");
         } finally {
             setLoading(false);
         }
-    };
+    }, [loadStrikeCounts]);
 
-    // Sólo permitimos edición, no creación desde el panel admin
-    // const openCreateModal = () => {
-    //     Alert.alert(
-    //         'Acción no disponible',
-    //         'La creación de usuarios no está permitida desde el panel de administración.',
-    //     );
-    // };
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            fetchUsers();
+        }, 500);
+        return () => clearTimeout(timer);
+    }, [fetchUsers]);
 
     const openEditModal = (user) => {
         setEditingUser(user);
@@ -84,7 +123,6 @@ export default function AdminUsersScreen() {
 
                 setUsers(prev => prev.map(u => (u.id === editingUser.id ? updated : u)));
             } else {
-                // Creación deshabilitada desde el panel admin
                 Alert.alert(
                     'Action not available',
                     'User creation must be done through the app signup flow.',
@@ -95,7 +133,6 @@ export default function AdminUsersScreen() {
             setModalVisible(false);
             setEditingUser(null);
         } catch (error) {
-            console.error('Error saving user', error?.response || error);
             const msg =
                 error?.response?.data?.message ||
                 error?.response?.data?.error ||
@@ -105,18 +142,78 @@ export default function AdminUsersScreen() {
     };
 
     const handleDeleteUser = async (user) => {
-        try {
-            console.log('Deleting user directly:', user.id);
-            const res = await apiClient.delete(`/api/v1/users/${user.id}`);
-            console.log('Delete response status:', res.status, 'data:', res.data);
+        setUserToDelete(user);
+        setConfirmDeleteVisible(true);
+    };
 
-            setUsers(prev => prev.filter(u => u.id !== user.id));
-        } catch (error) {
-            console.error(
-                'Error deleting user:',
-                error?.response?.status,
-                error?.response?.data || error,
+    const confirmDeleteUserAction = async () => {
+        try {
+            await apiClient.delete(
+                `/api/v1/moderation/users/${userToDelete.id}`,
+                {
+                    params: {
+                        confirm: true
+                    }
+                }
             );
+
+            setUsers(prev => prev.filter(u => u.id !== userToDelete.id));
+            setConfirmDeleteVisible(false);
+            setUserToDelete(null);
+            Alert.alert('Éxito', 'Usuario eliminado correctamente');
+        } catch (error) {
+            let msg = 'No se pudo eliminar el usuario';
+
+            if (error?.response?.status === 403) {
+                msg = 'No tienes permiso para eliminar este usuario (debes ser admin)';
+            } else if (error?.response?.status === 400) {
+                msg = error?.response?.data?.message || 'Solicitud inválida';
+            } else if (error?.response?.status === 404) {
+                msg = 'Usuario no encontrado';
+            } else if (error?.response?.status === 401) {
+                msg = 'No autenticado. Por favor inicia sesión de nuevo';
+            } else if (error?.response?.data?.message) {
+                msg = error.response.data.message;
+            } else if (error?.message) {
+                msg = error.message;
+            }
+
+            Alert.alert('Error', msg);
+        }
+    };
+
+    const openStrikeModal = (user) => {
+        setSelectedUserForStrike(user);
+        setStrikeForm({ reason: '', description: '' });
+        setStrikeModalVisible(true);
+    };
+
+    const handleSendStrike = async () => {
+        if (!strikeForm.reason.trim()) {
+            Alert.alert('Error', 'El motivo del strike es obligatorio');
+            return;
+        }
+
+        setConfirmStrikeVisible(true);
+    };
+
+    const confirmStrikeAction = async () => {
+        try {
+            const payload = {
+                reason: strikeForm.reason,
+                description: strikeForm.description || null,
+            };
+
+            await apiClient.post(
+                `/api/v1/moderation/users/${selectedUserForStrike.id}/strike`,
+                payload
+            );
+            setStrikeModalVisible(false);
+            setConfirmStrikeVisible(false);
+            setSelectedUserForStrike(null);
+            setStrikeForm({ reason: '', description: '' });
+            Alert.alert('Éxito', 'Strike enviado correctamente al usuario');
+        } catch (error) {
             const msg =
                 error?.response?.data?.message ||
                 error?.response?.data?.error ||
@@ -134,11 +231,13 @@ export default function AdminUsersScreen() {
 
     const renderUserItem = ({ item }) => {
         const displayName = item.username || item.userName || '';
+        const isAdmin = item.authorities?.[0]?.authority === 'ADMIN' ||
+            item.authorities?.[0]?.authority === 'ROLE_ADMIN';
         return (
             <View style={styles.userCard}>
                 <View style={styles.userInfo}>
-                    <View style={[styles.avatar, { backgroundColor: item.role === 'ADMIN' ? '#e3f2fd' : '#f5f5f5' }]}>
-                        <Text style={[styles.avatarText, { color: item.role === 'ADMIN' ? '#007bff' : '#666' }]}>
+                    <View style={[styles.avatar, { backgroundColor: isAdmin ? '#e3f2fd' : '#f5f5f5' }]}>
+                        <Text style={[styles.avatarText, { color: isAdmin ? '#007bff' : '#666' }]}>
                             {displayName ? displayName.charAt(0).toUpperCase() : '?'}
                         </Text>
                     </View>
@@ -151,24 +250,44 @@ export default function AdminUsersScreen() {
                                     {item.active ? 'Active' : 'Inactive'}
                                 </Text>
                             </View>
-                            {item.role === 'ADMIN' && (
+                            {isAdmin && (
                                 <View style={[styles.badge, styles.adminBadge]}>
                                     <Text style={[styles.badgeText, styles.adminText]}>ADMIN</Text>
+                                </View>
+                            )}
+                            {strikeCounts[item.id] > 0 && (
+                                <View style={[styles.badge, styles.strikeBadge]}>
+                                    <Ionicons name="warning" size={14} color="#fff" />
+                                    <Text style={[styles.badgeText, styles.strikeText]}>{strikeCounts[item.id]}</Text>
                                 </View>
                             )}
                         </View>
                     </View>
                 </View>
                 <View style={styles.actions}>
+                    {!isAdmin && (
+                        <TouchableOpacity
+                            style={[styles.actionButton, { backgroundColor: '#fff3cd' }]}
+                            onPress={() => openStrikeModal(item)}
+                            activeOpacity={0.7}
+                            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                        >
+                            <Ionicons name="warning" size={20} color="#ff6b6b" />
+                        </TouchableOpacity>
+                    )}
                     <TouchableOpacity
                         style={[styles.actionButton, { backgroundColor: '#e3f2fd' }]}
                         onPress={() => openEditModal(item)}
+                        activeOpacity={0.7}
+                        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                     >
                         <Ionicons name="pencil-outline" size={20} color="#007bff" />
                     </TouchableOpacity>
                     <TouchableOpacity
                         style={[styles.actionButton, styles.deleteButton]}
                         onPress={() => handleDeleteUser(item)}
+                        activeOpacity={0.7}
+                        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                     >
                         <Ionicons name="trash-outline" size={20} color="#d90429" />
                     </TouchableOpacity>
@@ -265,6 +384,133 @@ export default function AdminUsersScreen() {
                     </View>
                 </View>
             </Modal>
+
+            <Modal
+                visible={strikeModalVisible}
+                transparent
+                animationType="slide"
+                onRequestClose={() => setStrikeModalVisible(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.modalContent}>
+                        <Text style={styles.modalTitle}>Enviar Strike</Text>
+                        <Text style={styles.modalSubtitle}>
+                            {selectedUserForStrike && `Usuario: ${selectedUserForStrike.username || selectedUserForStrike.userName}`}
+                        </Text>
+
+                        <View style={styles.modalField}>
+                            <Text style={styles.inputLabel}>Motivo *</Text>
+                            <TextInput
+                                style={styles.modalInput}
+                                placeholder="Ej: Contenido inapropiado, spam, violación de normas..."
+                                value={strikeForm.reason}
+                                onChangeText={(text) => setStrikeForm(prev => ({ ...prev, reason: text }))}
+                                multiline={true}
+                                numberOfLines={3}
+                                textAlignVertical="top"
+                            />
+                        </View>
+
+                        <View style={styles.modalField}>
+                            <Text style={styles.inputLabel}>Descripción (opcional)</Text>
+                            <TextInput
+                                style={styles.modalInput}
+                                placeholder="Detalles adicionales sobre el strike..."
+                                value={strikeForm.description}
+                                onChangeText={(text) => setStrikeForm(prev => ({ ...prev, description: text }))}
+                                multiline={true}
+                                numberOfLines={3}
+                                textAlignVertical="top"
+                            />
+                        </View>
+
+                        <View style={styles.modalActions}>
+                            <TouchableOpacity
+                                style={[styles.modalButton, styles.cancelButton]}
+                                onPress={() => setStrikeModalVisible(false)}
+                            >
+                                <Text style={styles.cancelButtonText}>Cancelar</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                                style={[styles.modalButton, styles.strikeButton]}
+                                onPress={handleSendStrike}
+                            >
+                                <Text style={styles.strikeButtonText}>Enviar Strike</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                </View>
+            </Modal>
+
+            <Modal
+                visible={confirmDeleteVisible}
+                transparent
+                animationType="fade"
+                onRequestClose={() => setConfirmDeleteVisible(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.confirmDialogContent}>
+                        <Ionicons name="trash-outline" size={48} color="#d90429" style={{ marginBottom: 16 }} />
+                        <Text style={styles.confirmDialogTitle}>Confirmar eliminación</Text>
+                        <Text style={styles.confirmDialogMessage}>
+                            ¿Estás seguro de que deseas eliminar la cuenta de {userToDelete?.username || userToDelete?.userName}?
+                        </Text>
+                        <Text style={styles.confirmDialogWarning}>
+                            Esta acción no se puede deshacer.
+                        </Text>
+
+                        <View style={styles.confirmDialogActions}>
+                            <TouchableOpacity
+                                style={[styles.dialogButton, styles.dialogCancelButton]}
+                                onPress={() => setConfirmDeleteVisible(false)}
+                            >
+                                <Text style={styles.dialogCancelButtonText}>Cancelar</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                                style={[styles.dialogButton, styles.dialogDeleteButton]}
+                                onPress={confirmDeleteUserAction}
+                            >
+                                <Text style={styles.dialogDeleteButtonText}>Eliminar usuario</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                </View>
+            </Modal>
+
+            <Modal
+                visible={confirmStrikeVisible}
+                transparent
+                animationType="fade"
+                onRequestClose={() => setConfirmStrikeVisible(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.confirmDialogContent}>
+                        <Ionicons name="warning" size={48} color="#ff9800" style={{ marginBottom: 16 }} />
+                        <Text style={styles.confirmDialogTitle}>Confirmar strike</Text>
+                        <Text style={styles.confirmDialogMessage}>
+                            ¿Estás seguro de que deseas enviar un strike a {selectedUserForStrike?.username || selectedUserForStrike?.userName}?
+                        </Text>
+                        <Text style={styles.confirmDialogWarning}>
+                            Motivo: {strikeForm.reason}
+                        </Text>
+
+                        <View style={styles.confirmDialogActions}>
+                            <TouchableOpacity
+                                style={[styles.dialogButton, styles.dialogCancelButton]}
+                                onPress={() => setConfirmStrikeVisible(false)}
+                            >
+                                <Text style={styles.dialogCancelButtonText}>Cancelar</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                                style={[styles.dialogButton, styles.dialogStrikeButton]}
+                                onPress={confirmStrikeAction}
+                            >
+                                <Text style={styles.dialogStrikeButtonText}>Enviar strike</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                </View>
+            </Modal>
         </SafeAreaView>
     );
 }
@@ -336,9 +582,26 @@ const styles = StyleSheet.create({
     inactiveText: { color: '#c62828' },
     adminBadge: { backgroundColor: '#e3f2fd' },
     adminText: { color: '#1565c0' },
-    actions: { flexDirection: 'row' },
-    actionButton: { padding: 8, marginLeft: 5, borderRadius: 8, backgroundColor: '#f5f5f5' },
-    deleteButton: { backgroundColor: '#ffebee' },
+    strikeBadge: { backgroundColor: '#ff9800', flexDirection: 'row', alignItems: 'center', gap: 4 },
+    strikeText: { color: '#fff' },
+    actions: {
+        flexDirection: 'row',
+        gap: 5,
+        justifyContent: 'flex-end'
+    },
+    actionButton: {
+        padding: 10,
+        marginLeft: 5,
+        borderRadius: 8,
+        backgroundColor: '#f5f5f5',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minWidth: 40,
+        minHeight: 40
+    },
+    deleteButton: {
+        backgroundColor: '#ffebee'
+    },
     modalOverlay: {
         flex: 1,
         backgroundColor: 'rgba(0,0,0,0.4)',
@@ -369,4 +632,71 @@ const styles = StyleSheet.create({
     cancelButtonText: { color: '#6b7280', fontWeight: '600' },
     saveButton: { backgroundColor: '#2563eb' },
     saveButtonText: { color: 'white', fontWeight: '600' },
+    strikeButton: { backgroundColor: '#ff6b6b' },
+    strikeButtonText: { color: 'white', fontWeight: '600' },
+    modalSubtitle: { fontSize: 14, color: '#666', marginBottom: 12 },
+    confirmDialogContent: {
+        width: '85%',
+        maxWidth: 380,
+        backgroundColor: 'white',
+        borderRadius: 16,
+        padding: 24,
+        alignItems: 'center',
+    },
+    confirmDialogTitle: {
+        fontSize: 18,
+        fontWeight: 'bold',
+        color: '#111827',
+        marginBottom: 12,
+        textAlign: 'center'
+    },
+    confirmDialogMessage: {
+        fontSize: 14,
+        color: '#4b5563',
+        textAlign: 'center',
+        marginBottom: 8,
+    },
+    confirmDialogWarning: {
+        fontSize: 13,
+        color: '#d90429',
+        textAlign: 'center',
+        marginBottom: 20,
+        fontWeight: '600',
+    },
+    confirmDialogActions: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        width: '100%',
+        gap: 12,
+    },
+    dialogButton: {
+        flex: 1,
+        paddingVertical: 12,
+        borderRadius: 8,
+        alignItems: 'center',
+    },
+    dialogCancelButton: {
+        backgroundColor: '#f3f4f6',
+    },
+    dialogCancelButtonText: {
+        color: '#6b7280',
+        fontWeight: '600',
+        fontSize: 14,
+    },
+    dialogDeleteButton: {
+        backgroundColor: '#d90429',
+    },
+    dialogDeleteButtonText: {
+        color: 'white',
+        fontWeight: '600',
+        fontSize: 14,
+    },
+    dialogStrikeButton: {
+        backgroundColor: '#ff9800',
+    },
+    dialogStrikeButtonText: {
+        color: 'white',
+        fontWeight: '600',
+        fontSize: 14,
+    },
 });

--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
@@ -85,13 +81,17 @@
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
+            <groupId>com.sendgrid</groupId>
+            <artifactId>sendgrid-java</artifactId>
+            <version>4.10.2</version>
         </dependency>
+
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-mysql</artifactId>
+            <groupId>com.sendgrid</groupId>
+            <artifactId>sendgrid-java</artifactId>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- H2 Database - for development and testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,16 @@
             <version>4.10.2</version>
         </dependency>
 
+        <!-- Jakarta Mail -->
         <dependency>
-            <groupId>com.sendgrid</groupId>
-            <artifactId>sendgrid-java</artifactId>
-            <version>4.10.2</version>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>2.0.1</version>
         </dependency>
 
         <!-- H2 Database - for development and testing -->

--- a/src/main/java/com/streetask/app/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/streetask/app/configuration/SecurityConfiguration.java
@@ -109,6 +109,9 @@ public class SecurityConfiguration {
 						// Push devices require auth
 						.requestMatchers("/api/push-devices/**").authenticated()
 
+						// Moderation endpoints require ADMIN authority
+						.requestMatchers("/api/v1/moderation/**").hasAuthority(ADMIN)
+
 						.anyRequest().denyAll())
 
 				.addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/streetask/app/functionalities/email/EmailService.java
+++ b/src/main/java/com/streetask/app/functionalities/email/EmailService.java
@@ -1,0 +1,48 @@
+package com.streetask.app.functionalities.email;
+
+import com.sendgrid.*;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmailService.class);
+
+    @Value("${sendgrid.api-key}")
+    private String sendgridApiKey;
+
+    public void sendAccountDeletionEmail(String toEmail) {
+        Email from = new Email("streetask0@gmail.com", "Streetask");
+        Email to   = new Email(toEmail);
+
+        String subject = "Tu cuenta ha sido eliminada";
+        Content content = new Content("text/plain",
+            "Hola,\n\n" +
+            "Te informamos de que tu cuenta en Streetask ha sido eliminada por el equipo de moderación " +
+            "debido al incumplimiento de nuestras normas de uso.\n\n" +
+            "Si crees que esto es un error, puedes ponerte en contacto con nosotros respondiendo a este correo.\n\n" +
+            "Atentamente,\n" +
+            "El Equipo de Streetask"
+        );
+
+        Mail mail = new Mail(from, subject, to, content);
+
+        SendGrid sg = new SendGrid(sendgridApiKey);
+        Request request = new Request();
+        try {
+            request.setMethod(Method.POST);
+            request.setEndpoint("mail/send");
+            request.setBody(mail.build());
+            Response response = sg.api(request);
+            logger.info("[EmailService] Deletion email sent to {}. Status: {}", toEmail, response.getStatusCode());
+        } catch (Exception e) {
+            // No bloqueamos el flujo principal si el email falla
+            logger.error("[EmailService] Failed to send deletion email to {}: {}", toEmail, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/streetask/app/functionalities/notifications/model/Notification.java
+++ b/src/main/java/com/streetask/app/functionalities/notifications/model/Notification.java
@@ -3,6 +3,7 @@ package com.streetask.app.functionalities.notifications.model;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.streetask.app.model.BaseEntity;
 import com.streetask.app.user.RegularUser;
 
@@ -21,6 +22,7 @@ import lombok.Setter;
 @Setter
 public class Notification extends BaseEntity {
 
+    @JsonIgnore
     @ManyToOne(optional = false)
     @JoinColumn(name = "user_id")
     private RegularUser user;

--- a/src/main/java/com/streetask/app/functionalities/notifications/model/NotificationRepository.java
+++ b/src/main/java/com/streetask/app/functionalities/notifications/model/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.streetask.app.functionalities.notifications.model;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.streetask.app.user.RegularUser;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+    void deleteByUser(RegularUser user);
+}

--- a/src/main/java/com/streetask/app/functionalities/notifications/model/NotificationType.java
+++ b/src/main/java/com/streetask/app/functionalities/notifications/model/NotificationType.java
@@ -3,5 +3,6 @@ package com.streetask.app.functionalities.notifications.model;
 public enum NotificationType {
     NEARBY_QUESTION,
     NEARBY_EVENT,
-    ANSWER_TO_QUESTION
+    ANSWER_TO_QUESTION,
+    STRIKE
 }

--- a/src/main/java/com/streetask/app/model/Strike.java
+++ b/src/main/java/com/streetask/app/model/Strike.java
@@ -1,0 +1,47 @@
+package com.streetask.app.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.streetask.app.user.RegularUser;
+import com.streetask.app.user.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "strikes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Strike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private RegularUser user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issued_by_id", nullable = false)
+    private User issuedBy;
+
+    private String reason;
+
+    private String description;
+
+    private LocalDateTime issuedAt;
+}

--- a/src/main/java/com/streetask/app/moderation/ModerationController.java
+++ b/src/main/java/com/streetask/app/moderation/ModerationController.java
@@ -1,0 +1,66 @@
+package com.streetask.app.moderation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.streetask.app.auth.payload.response.MessageResponse;
+import com.streetask.app.model.Strike;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/moderation/users")
+@SecurityRequirement(name = "bearerAuth")
+@RequiredArgsConstructor
+@Validated
+public class ModerationController {
+
+    private final ModerationService moderationService;
+
+    @PostMapping("/{userId}/strike")
+    public ResponseEntity<MessageResponse> sendStrike(@PathVariable UUID userId, @Valid @RequestBody StrikeRequest body) {
+        Strike strike = moderationService.issueStrike(userId, body.getReason(), body.getDescription());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new MessageResponse("Strike sent successfully. Strike ID: " + strike.getId()));
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<MessageResponse> deleteUser(
+            @PathVariable UUID userId,
+            @RequestParam(defaultValue = "false") boolean confirm) {
+        
+        if (!confirm) {
+            return ResponseEntity.badRequest().body(new MessageResponse("Deletion requires confirmation. Use confirm=true."));
+        }
+
+        moderationService.deleteRegularUser(userId);
+        return ResponseEntity.ok(new MessageResponse("User account deleted successfully."));
+    }
+
+    @GetMapping("/{userId}/strike-count")
+    public ResponseEntity<Map<String, Long>> getStrikeCount(@PathVariable UUID userId) {
+        long count = moderationService.getStrikeCount(userId);
+        return ResponseEntity.ok(Map.of("count", count));
+    }
+
+    @GetMapping("/{userId}/strikes")
+    public ResponseEntity<List<Strike>> getUserStrikes(@PathVariable UUID userId) {
+        List<Strike> strikes = moderationService.getUserStrikes(userId);
+        return ResponseEntity.ok(strikes);
+    }
+}

--- a/src/main/java/com/streetask/app/moderation/ModerationService.java
+++ b/src/main/java/com/streetask/app/moderation/ModerationService.java
@@ -1,0 +1,134 @@
+package com.streetask.app.moderation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.streetask.app.exceptions.AccessDeniedException;
+import com.streetask.app.functionalities.email.EmailService;
+import com.streetask.app.functionalities.notifications.model.Notification;
+import com.streetask.app.functionalities.notifications.model.NotificationRepository;
+import com.streetask.app.functionalities.notifications.model.NotificationType;
+import com.streetask.app.functionalities.notifications.realtime.FrontendNotificationGateway;
+import com.streetask.app.functionalities.notifications.realtime.FrontendNotificationMessage;
+import com.streetask.app.model.Strike;
+import com.streetask.app.user.RegularUser;
+import com.streetask.app.user.User;
+import com.streetask.app.user.UserRepository;
+import com.streetask.app.user.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ModerationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ModerationService.class);
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final StrikeRepository strikeRepository;
+    private final NotificationRepository notificationRepository;
+    private final FrontendNotificationGateway frontendNotificationGateway;
+    private final EmailService emailService;
+
+    @Transactional
+    public Strike issueStrike(UUID userId, String reason, String description) {
+        User currentUser = userService.findCurrentUser();
+        if (!currentUser.hasAuthority("ADMIN")) {
+            logger.warn("[ModerationService] Non-admin user {} tried to issue strike", currentUser.getId());
+            throw new AccessDeniedException("Only admins can send strikes");
+        }
+
+        RegularUser targetUser = getModeratableUser(userId);
+
+        Strike strike = new Strike();
+        strike.setUser(targetUser);
+        strike.setIssuedBy(currentUser);
+        strike.setReason(reason);
+        strike.setDescription(description);
+        strike.setIssuedAt(LocalDateTime.now());
+        Strike savedStrike = strikeRepository.save(strike);
+
+        Notification notification = new Notification();
+        notification.setUser(targetUser);
+        notification.setType(NotificationType.STRIKE);
+        notification.setContent("You have received a moderation strike: " + reason);
+        notification.setReferenceId(savedStrike.getId());
+        notification.setReferenceType("STRIKE");
+        notification.setSentAt(LocalDateTime.now());
+        notificationRepository.save(notification);
+
+        FrontendNotificationMessage websocketMessage = FrontendNotificationMessage.builder()
+                .type("STRIKE")
+                .title("Moderation warning")
+                .message("You have received a moderation strike: " + reason)
+                .referenceId(savedStrike.getId())
+                .referenceType("STRIKE")
+                .timestamp(LocalDateTime.now())
+                .build();
+        frontendNotificationGateway.sendToUser(targetUser.getEmail(), websocketMessage);
+
+        return savedStrike;
+    }
+
+    @Transactional
+    public void deleteRegularUser(UUID userId) {
+        User currentUser = userService.findCurrentUser();
+
+        if (!currentUser.hasAuthority("ADMIN")) {
+            logger.warn("[ModerationService] Non-admin user {} tried to delete user {}", currentUser.getId(), userId);
+            throw new AccessDeniedException("Only admins can delete users");
+        }
+
+        if (currentUser.getId().equals(userId)) {
+            logger.warn("[ModerationService] Admin {} attempted to delete themselves", currentUser.getId());
+            throw new AccessDeniedException("Admins cannot delete themselves");
+        }
+
+        RegularUser targetUser = getModeratableUser(userId);
+        String userEmail = targetUser.getEmail();
+
+        List<Strike> userStrikes = strikeRepository.findByUserOrderByIssuedAtDesc(targetUser);
+        strikeRepository.deleteAll(userStrikes);
+
+        notificationRepository.deleteByUser(targetUser);
+        userRepository.delete(targetUser);
+        logger.info("[ModerationService] User deleted successfully: {}", userId);
+
+        emailService.sendAccountDeletionEmail(userEmail);
+    }
+
+    @Transactional(readOnly = true)
+    public long getStrikeCount(UUID userId) {
+        User currentUser = userService.findCurrentUser();
+        if (currentUser.getAuthority() != null && !currentUser.hasAuthority("ADMIN")) {
+            throw new AccessDeniedException("Only admins can view strike counts");
+        }
+        RegularUser targetUser = getModeratableUser(userId);
+        return strikeRepository.countByUser(targetUser);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Strike> getUserStrikes(UUID userId) {
+        User currentUser = userService.findCurrentUser();
+        if (!currentUser.hasAuthority("ADMIN")) {
+            throw new AccessDeniedException("Only admins can view strikes");
+        }
+        RegularUser targetUser = getModeratableUser(userId);
+        return strikeRepository.findByUserOrderByIssuedAtDesc(targetUser);
+    }
+
+    private RegularUser getModeratableUser(UUID userId) {
+        User targetUser = userService.findUser(userId);
+        if (!(targetUser instanceof RegularUser regularUser)) {
+            logger.warn("[ModerationService] Attempted to moderate non-regular user: {}", userId);
+            throw new AccessDeniedException("Moderation actions only apply to regular users");
+        }
+        return regularUser;
+    }
+}

--- a/src/main/java/com/streetask/app/moderation/StrikeRepository.java
+++ b/src/main/java/com/streetask/app/moderation/StrikeRepository.java
@@ -1,0 +1,14 @@
+package com.streetask.app.moderation;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.streetask.app.model.Strike;
+import com.streetask.app.user.RegularUser;
+
+public interface StrikeRepository extends JpaRepository<Strike, UUID> {
+    List<Strike> findByUserOrderByIssuedAtDesc(RegularUser user);
+    long countByUser(RegularUser user);
+}

--- a/src/main/java/com/streetask/app/moderation/StrikeRequest.java
+++ b/src/main/java/com/streetask/app/moderation/StrikeRequest.java
@@ -1,0 +1,17 @@
+package com.streetask.app.moderation;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StrikeRequest {
+    
+    @NotBlank(message = "Reason is required")
+    private String reason;
+    
+    private String description;
+}

--- a/src/main/java/com/streetask/app/user/RegularUser.java
+++ b/src/main/java/com/streetask/app/user/RegularUser.java
@@ -8,8 +8,10 @@ import com.streetask.app.model.CoinTransaction;
 import com.streetask.app.model.EventAttendance;
 import com.streetask.app.model.Question;
 import com.streetask.app.model.Report;
+import com.streetask.app.model.Strike;
 import com.streetask.app.functionalities.notifications.model.Notification;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -63,4 +65,8 @@ public class RegularUser extends User {
     @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = jakarta.persistence.CascadeType.REMOVE)
     private java.util.List<com.streetask.app.functionalities.notifications.push.model.PushDevice> pushDevices;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Strike> strikes;
 }

--- a/src/main/java/com/streetask/app/user/User.java
+++ b/src/main/java/com/streetask/app/user/User.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size; // Importado para la bio
 import lombok.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -62,9 +63,14 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private java.util.List<com.streetask.app.functionalities.feedback.FeedbackMessage> feedbackMessages;
 
+	  @com.fasterxml.jackson.annotation.JsonIgnore
+	  @OneToMany(mappedBy = "issuedBy", cascade = CascadeType.REMOVE)
+	  private List<com.streetask.app.model.Strike> issuedStrikes;
+
     @com.fasterxml.jackson.annotation.JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private java.util.List<com.streetask.app.model.UserLocation> locations;
+
 
     public Boolean hasAuthority(String auth) {
         return authority.getAuthority().equals(auth);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,3 +84,6 @@ streetask.websocket.topic.user-queue=/queue/notifications
 streetask.web-push.subject=${STREETASK_WEB_PUSH_SUBJECT:mailto:streetask.notifications@gmail.com}
 streetask.web-push.public-key=${STREETASK_WEB_PUSH_PUBLIC_KEY:BCzmM4oFvgyIoji531RyMjAMxwSEcgRHivSvGBtDeP93MssCAQdfnZZlZ-24mpUMGlCRselBYpHj1onx9eHwqcQ}
 streetask.web-push.private-key=${STREETASK_WEB_PUSH_PRIVATE_KEY:xS6S6T2vAkW3mr43IsHOeb6J1DzkXA2AxcGn88z7uq8}
+
+#Mail
+sendgrid.api-key=${SENDGRID_API_KEY:}

--- a/src/test/java/com/streetask/app/moderation/ModerationControllerTest.java
+++ b/src/test/java/com/streetask/app/moderation/ModerationControllerTest.java
@@ -1,0 +1,360 @@
+package com.streetask.app.moderation;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.streetask.app.exceptions.AccessDeniedException;
+import com.streetask.app.model.Strike;
+import com.streetask.app.user.Authorities;
+import com.streetask.app.user.RegularUser;
+import com.streetask.app.user.User;
+
+@WebMvcTest(ModerationController.class)
+@DisplayName("ModerationController Unit Tests")
+class ModerationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ModerationService moderationService;
+
+    private UUID adminId;
+    private UUID regularUserId;
+    private User adminUser;
+    private RegularUser regularUser;
+
+    private static final String ADMIN_EMAIL = "admin@test.com";
+    private static final String REGULAR_USER_EMAIL = "user@test.com";
+
+    @BeforeEach
+    void setUp() {
+        adminId = UUID.randomUUID();
+        regularUserId = UUID.randomUUID();
+
+        adminUser = new User();
+        adminUser.setId(adminId);
+        adminUser.setEmail(ADMIN_EMAIL);
+        Authorities adminAuthority = new Authorities();
+        adminAuthority.setAuthority("ADMIN");
+        adminUser.setAuthority(adminAuthority);
+
+        regularUser = new RegularUser();
+        regularUser.setId(regularUserId);
+        regularUser.setEmail(REGULAR_USER_EMAIL);
+        Authorities userAuthority = new Authorities();
+        userAuthority.setAuthority("USER");
+        regularUser.setAuthority(userAuthority);
+    }
+
+    // ================= SEND STRIKE TESTS =================
+
+    @Test
+    @DisplayName("POST /api/v1/moderation/users/{userId}/strike should send strike successfully")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void sendStrike_shouldReturnCreatedStatus() throws Exception {
+        // Arrange
+        StrikeRequest request = new StrikeRequest();
+        request.setReason("Inappropriate content");
+        request.setDescription("Violated community guidelines");
+
+        Strike createdStrike = new Strike();
+        createdStrike.setId(UUID.randomUUID());
+        createdStrike.setUser(regularUser);
+        createdStrike.setIssuedBy(adminUser);
+        createdStrike.setReason(request.getReason());
+        createdStrike.setDescription(request.getDescription());
+        createdStrike.setIssuedAt(LocalDateTime.now());
+
+        when(moderationService.issueStrike(
+            eq(regularUserId),
+            eq(request.getReason()),
+            eq(request.getDescription())
+        )).thenReturn(createdStrike);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/moderation/users/{userId}/strike", regularUserId)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("Strike sent successfully. Strike ID: " + createdStrike.getId()));
+
+        verify(moderationService).issueStrike(
+            eq(regularUserId),
+            eq(request.getReason()),
+            eq(request.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/moderation/users/{userId}/strike should return bad request when reason is empty")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void sendStrike_shouldReturnBadRequestWhenReasonIsEmpty() throws Exception {
+        // Arrange
+        StrikeRequest request = new StrikeRequest();
+        request.setReason(""); // Empty reason
+        request.setDescription("Some description");
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/moderation/users/{userId}/strike", regularUserId)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/moderation/users/{userId}/strike should return forbidden when user is not admin")
+    @WithMockUser(username = "user@test.com", authorities = "USER")
+    void sendStrike_shouldReturnForbiddenWhenNotAdmin() throws Exception {
+        // Arrange
+        StrikeRequest request = new StrikeRequest();
+        request.setReason("Spam");
+        request.setDescription("");
+
+        when(moderationService.issueStrike(any(), any(), any()))
+            .thenThrow(new AccessDeniedException("Only admins can send strikes"));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/moderation/users/{userId}/strike", regularUserId)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/moderation/users/{userId}/strike should return unauthorized when not authenticated")
+    void sendStrike_shouldReturnUnauthorizedWhenNotAuthenticated() throws Exception {
+        // Arrange
+        StrikeRequest request = new StrikeRequest();
+        request.setReason("Spam");
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/moderation/users/{userId}/strike", regularUserId)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ================= DELETE USER TESTS =================
+
+    @Test
+    @DisplayName("DELETE /api/v1/moderation/users/{userId} should delete user successfully with confirmation")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void deleteUser_shouldDeleteSuccessfullyWithConfirmation() throws Exception {
+        // Arrange
+        doNothing().when(moderationService).deleteRegularUser(regularUserId);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/moderation/users/{userId}", regularUserId)
+                .param("confirm", "true")
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("User account deleted successfully."));
+
+        verify(moderationService).deleteRegularUser(regularUserId);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/moderation/users/{userId} should return bad request without confirmation")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void deleteUser_shouldReturnBadRequestWithoutConfirmation() throws Exception {
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/moderation/users/{userId}", regularUserId)
+                .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Deletion requires confirmation. Use confirm=true."));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/moderation/users/{userId} should return bad request when confirm is false")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void deleteUser_shouldReturnBadRequestWhenConfirmIsFalse() throws Exception {
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/moderation/users/{userId}", regularUserId)
+                .param("confirm", "false")
+                .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Deletion requires confirmation. Use confirm=true."));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/moderation/users/{userId} should return forbidden when user is not admin")
+    @WithMockUser(username = "user@test.com", authorities = "USER")
+    void deleteUser_shouldReturnForbiddenWhenNotAdmin() throws Exception {
+        // Arrange
+        doThrow(new AccessDeniedException("Only admins can delete users"))
+            .when(moderationService).deleteRegularUser(regularUserId);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/moderation/users/{userId}", regularUserId)
+                .param("confirm", "true")
+                .with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/moderation/users/{userId} should return unauthorized when not authenticated")
+    void deleteUser_shouldReturnUnauthorizedWhenNotAuthenticated() throws Exception {
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/moderation/users/{userId}", regularUserId)
+                .param("confirm", "true")
+                .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ================= GET STRIKE COUNT TESTS =================
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strike-count should return strike count")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void getStrikeCount_shouldReturnStrikeCount() throws Exception {
+        // Arrange
+        when(moderationService.getStrikeCount(regularUserId)).thenReturn(3L);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strike-count", regularUserId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count", is(3)));
+
+        verify(moderationService).getStrikeCount(regularUserId);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strike-count should return zero when user has no strikes")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void getStrikeCount_shouldReturnZeroWhenNoStrikes() throws Exception {
+        // Arrange
+        when(moderationService.getStrikeCount(regularUserId)).thenReturn(0L);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strike-count", regularUserId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count", is(0)));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strike-count should return forbidden when not admin")
+    @WithMockUser(username = "user@test.com", authorities = "USER")
+    void getStrikeCount_shouldReturnForbiddenWhenNotAdmin() throws Exception {
+        // Arrange
+        when(moderationService.getStrikeCount(regularUserId))
+            .thenThrow(new AccessDeniedException("Only admins can view strike counts"));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strike-count", regularUserId))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strike-count should return unauthorized when not authenticated")
+    void getStrikeCount_shouldReturnUnauthorizedWhenNotAuthenticated() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strike-count", regularUserId))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ================= GET USER STRIKES TESTS =================
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strikes should return all strikes for user")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void getUserStrikes_shouldReturnAllStrikes() throws Exception {
+        // Arrange
+        List<Strike> strikes = Arrays.asList(
+            createStrike(adminUser, regularUser, "Spam"),
+            createStrike(adminUser, regularUser, "Abuse")
+        );
+
+        when(moderationService.getUserStrikes(regularUserId)).thenReturn(strikes);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strikes", regularUserId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].reason", is("Spam")))
+                .andExpect(jsonPath("$[1].reason", is("Abuse")));
+
+        verify(moderationService).getUserStrikes(regularUserId);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strikes should return empty array when no strikes")
+    @WithMockUser(username = "admin@test.com", authorities = "ADMIN")
+    void getUserStrikes_shouldReturnEmptyArrayWhenNoStrikes() throws Exception {
+        // Arrange
+        when(moderationService.getUserStrikes(regularUserId)).thenReturn(Arrays.asList());
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strikes", regularUserId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strikes should return forbidden when not admin")
+    @WithMockUser(username = "user@test.com", authorities = "USER")
+    void getUserStrikes_shouldReturnForbiddenWhenNotAdmin() throws Exception {
+        // Arrange
+        when(moderationService.getUserStrikes(regularUserId))
+            .thenThrow(new AccessDeniedException("Only admins can view strikes"));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strikes", regularUserId))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/moderation/users/{userId}/strikes should return unauthorized when not authenticated")
+    void getUserStrikes_shouldReturnUnauthorizedWhenNotAuthenticated() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/moderation/users/{userId}/strikes", regularUserId))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ================= HELPER METHODS =================
+
+    private Strike createStrike(User issuedBy, RegularUser user, String reason) {
+        Strike strike = new Strike();
+        strike.setId(UUID.randomUUID());
+        strike.setIssuedBy(issuedBy);
+        strike.setUser(user);
+        strike.setReason(reason);
+        strike.setIssuedAt(LocalDateTime.now());
+        return strike;
+    }
+}

--- a/src/test/java/com/streetask/app/moderation/ModerationServiceTest.java
+++ b/src/test/java/com/streetask/app/moderation/ModerationServiceTest.java
@@ -1,0 +1,386 @@
+package com.streetask.app.moderation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.streetask.app.exceptions.AccessDeniedException;
+import com.streetask.app.functionalities.email.EmailService;
+import com.streetask.app.functionalities.notifications.model.Notification;
+import com.streetask.app.functionalities.notifications.model.NotificationRepository;
+import com.streetask.app.functionalities.notifications.model.NotificationType;
+import com.streetask.app.functionalities.notifications.realtime.FrontendNotificationGateway;
+import com.streetask.app.functionalities.notifications.realtime.FrontendNotificationMessage;
+import com.streetask.app.model.Strike;
+import com.streetask.app.user.Authorities;
+import com.streetask.app.user.RegularUser;
+import com.streetask.app.user.User;
+import com.streetask.app.user.UserRepository;
+import com.streetask.app.user.UserService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ModerationService Unit Tests")
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ModerationServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StrikeRepository strikeRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private FrontendNotificationGateway frontendNotificationGateway;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private ModerationService moderationService;
+
+    private User adminUser;
+    private RegularUser regularUser;
+    private UUID adminId;
+    private UUID regularUserId;
+
+    private static final String ADMIN_EMAIL = "admin@test.com";
+    private static final String REGULAR_USER_EMAIL = "user@test.com";
+
+    @BeforeEach
+    void setUp() {
+        adminId = UUID.randomUUID();
+        regularUserId = UUID.randomUUID();
+
+        // Create admin user
+        adminUser = new User();
+        adminUser.setId(adminId);
+        adminUser.setEmail(ADMIN_EMAIL);
+        adminUser.setUserName("admin");
+        Authorities adminAuthority = new Authorities();
+        adminAuthority.setAuthority("ADMIN");
+        adminUser.setAuthority(adminAuthority);
+
+        // Create regular user
+        regularUser = new RegularUser();
+        regularUser.setId(regularUserId);
+        regularUser.setEmail(REGULAR_USER_EMAIL);
+        regularUser.setUserName("regularuser");
+        Authorities userAuthority = new Authorities();
+        userAuthority.setAuthority("USER");
+        regularUser.setAuthority(userAuthority);
+
+        // Setup security context with admin
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = org.mockito.Mockito.mock(Authentication.class);
+        when(authentication.getName()).thenReturn(ADMIN_EMAIL);
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ================= ISSUE STRIKE TESTS =================
+
+    @Test
+    @DisplayName("issueStrike should create strike successfully when admin issues strike to regular user")
+    void issueStrike_shouldCreateStrikeSuccessfully() {
+        // Arrange
+        String reason = "Inappropriate content";
+        String description = "Violated community guidelines";
+
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+        when(userService.findUser(regularUserId)).thenReturn(regularUser);
+
+        Strike expectedStrike = new Strike();
+        expectedStrike.setId(UUID.randomUUID());
+        expectedStrike.setUser(regularUser);
+        expectedStrike.setIssuedBy(adminUser);
+        expectedStrike.setReason(reason);
+        expectedStrike.setDescription(description);
+
+        when(strikeRepository.save(any(Strike.class))).thenReturn(expectedStrike);
+        when(notificationRepository.save(any(Notification.class))).thenReturn(new Notification());
+        doNothing().when(frontendNotificationGateway).sendToUser(anyString(), any(FrontendNotificationMessage.class));
+
+        // Act
+        Strike result = moderationService.issueStrike(regularUserId, reason, description);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(regularUser, result.getUser());
+        assertEquals(adminUser, result.getIssuedBy());
+        assertEquals(reason, result.getReason());
+        assertEquals(description, result.getDescription());
+
+        verify(strikeRepository).save(any(Strike.class));
+        verify(notificationRepository).save(any(Notification.class));
+        verify(frontendNotificationGateway).sendToUser(eq(REGULAR_USER_EMAIL), any(FrontendNotificationMessage.class));
+    }
+
+    @Test
+    @DisplayName("issueStrike should throw exception when non-admin tries to issue strike")
+    void issueStrike_shouldThrowExceptionWhenNonAdminIssuesStrike() {
+        // Arrange
+        User nonAdminUser = new User();
+        nonAdminUser.setId(UUID.randomUUID());
+        nonAdminUser.setEmail("user@test.com");
+        Authorities userAuthority = new Authorities();
+        userAuthority.setAuthority("USER");
+        nonAdminUser.setAuthority(userAuthority);
+
+        when(userService.findCurrentUser()).thenReturn(nonAdminUser);
+
+        // Act & Assert
+        assertThrows(AccessDeniedException.class, () ->
+            moderationService.issueStrike(regularUserId, "Spam", "Too many messages")
+        );
+
+        verify(strikeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("issueStrike should throw exception when trying to strike non-regular user")
+    void issueStrike_shouldThrowExceptionWhenStrikingNonRegularUser() {
+        // Arrange
+        User businessUser = new User();
+        businessUser.setId(UUID.randomUUID());
+        businessUser.setEmail("business@test.com");
+
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+        when(userService.findUser(businessUser.getId())).thenReturn(businessUser);
+
+        // Act & Assert
+        assertThrows(AccessDeniedException.class, () ->
+            moderationService.issueStrike(businessUser.getId(), "Spam", "")
+        );
+
+        verify(strikeRepository, never()).save(any());
+    }
+
+    // ================= DELETE USER TESTS =================
+
+    @Test
+    @DisplayName("deleteRegularUser should delete user and associated data successfully")
+    void deleteRegularUser_shouldDeleteSuccessfully() {
+        // Arrange
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+        when(userService.findUser(regularUserId)).thenReturn(regularUser);
+
+        List<Strike> userStrikes = Arrays.asList(
+            createStrike(adminUser, regularUser, "Spam"),
+            createStrike(adminUser, regularUser, "Abuse")
+        );
+
+        when(strikeRepository.findByUserOrderByIssuedAtDesc(regularUser))
+            .thenReturn(userStrikes);
+        doNothing().when(strikeRepository).deleteAll(userStrikes);
+        doNothing().when(notificationRepository).deleteByUser(regularUser);
+        doNothing().when(userRepository).delete(regularUser);
+        doNothing().when(emailService).sendAccountDeletionEmail(REGULAR_USER_EMAIL);
+
+        // Act
+        moderationService.deleteRegularUser(regularUserId);
+
+        // Assert
+        verify(strikeRepository).findByUserOrderByIssuedAtDesc(regularUser);
+        verify(strikeRepository).deleteAll(userStrikes);
+        verify(notificationRepository).deleteByUser(regularUser);
+        verify(userRepository).delete(regularUser);
+        verify(emailService).sendAccountDeletionEmail(REGULAR_USER_EMAIL);
+    }
+
+    @Test
+    @DisplayName("deleteRegularUser should throw exception when non-admin tries to delete")
+    void deleteRegularUser_shouldThrowExceptionWhenNonAdminDeletes() {
+        // Arrange
+        User nonAdminUser = new User();
+        nonAdminUser.setId(UUID.randomUUID());
+        Authorities userAuthority = new Authorities();
+        userAuthority.setAuthority("USER");
+        nonAdminUser.setAuthority(userAuthority);
+
+        when(userService.findCurrentUser()).thenReturn(nonAdminUser);
+
+        // Act & Assert
+        assertThrows(AccessDeniedException.class, () ->
+            moderationService.deleteRegularUser(regularUserId)
+        );
+
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("deleteRegularUser should throw exception when admin tries to delete themselves")
+    void deleteRegularUser_shouldThrowExceptionWhenAdminDeletesThemselves() {
+        // Arrange
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+
+        // Act & Assert
+        assertThrows(AccessDeniedException.class, () ->
+            moderationService.deleteRegularUser(adminId)
+        );
+
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("deleteRegularUser should throw exception when trying to delete non-regular user")
+    void deleteRegularUser_shouldThrowExceptionWhenDeletingNonRegularUser() {
+        // Arrange
+        User businessUser = new User();
+        businessUser.setId(UUID.randomUUID());
+
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+        when(userService.findUser(businessUser.getId())).thenReturn(businessUser);
+
+        // Act & Assert
+        assertThrows(AccessDeniedException.class, () ->
+            moderationService.deleteRegularUser(businessUser.getId())
+        );
+
+        verify(userRepository, never()).delete(any());
+    }
+
+    // ================= GET STRIKE COUNT TESTS =================
+
+    @Test
+    @DisplayName("getStrikeCount should return correct strike count")
+    void getStrikeCount_shouldReturnCorrectCount() {
+        // Arrange
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+        when(userService.findUser(regularUserId)).thenReturn(regularUser);
+        when(strikeRepository.countByUser(regularUser)).thenReturn(3L);
+
+        // Act
+        long count = moderationService.getStrikeCount(regularUserId);
+
+        // Assert
+        assertEquals(3L, count);
+        verify(strikeRepository).countByUser(regularUser);
+    }
+
+    @Test
+    @DisplayName("getStrikeCount should throw exception for non-admin")
+    void getStrikeCount_shouldThrowExceptionForNonAdmin() {
+        // Arrange
+        User nonAdminUser = new User();
+        nonAdminUser.setId(UUID.randomUUID());
+        Authorities userAuthority = new Authorities();
+        userAuthority.setAuthority("USER");
+        nonAdminUser.setAuthority(userAuthority);
+
+        when(userService.findCurrentUser()).thenReturn(nonAdminUser);
+
+        // Act & Assert
+        assertThrows(AccessDeniedException.class, () ->
+            moderationService.getStrikeCount(regularUserId)
+        );
+    }
+
+    // ================= GET USER STRIKES TESTS =================
+
+    @Test
+    @DisplayName("getUserStrikes should return all strikes for user")
+    void getUserStrikes_shouldReturnAllStrikes() {
+        // Arrange
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+        when(userService.findUser(regularUserId)).thenReturn(regularUser);
+
+        List<Strike> strikes = Arrays.asList(
+            createStrike(adminUser, regularUser, "Spam"),
+            createStrike(adminUser, regularUser, "Abuse")
+        );
+
+        when(strikeRepository.findByUserOrderByIssuedAtDesc(regularUser))
+            .thenReturn(strikes);
+
+        // Act
+        List<Strike> result = moderationService.getUserStrikes(regularUserId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(strikeRepository).findByUserOrderByIssuedAtDesc(regularUser);
+    }
+
+    @Test
+    @DisplayName("getUserStrikes should return empty list when user has no strikes")
+    void getUserStrikes_shouldReturnEmptyListWhenNoStrikes() {
+        // Arrange
+        when(userService.findCurrentUser()).thenReturn(adminUser);
+        when(userService.findUser(regularUserId)).thenReturn(regularUser);
+        when(strikeRepository.findByUserOrderByIssuedAtDesc(regularUser))
+            .thenReturn(Collections.emptyList());
+
+        // Act
+        List<Strike> result = moderationService.getUserStrikes(regularUserId);
+
+        // Assert
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    @DisplayName("getUserStrikes should throw exception for non-admin")
+    void getUserStrikes_shouldThrowExceptionForNonAdmin() {
+        // Arrange
+        User nonAdminUser = new User();
+        nonAdminUser.setId(UUID.randomUUID());
+        Authorities userAuthority = new Authorities();
+        userAuthority.setAuthority("USER");
+        nonAdminUser.setAuthority(userAuthority);
+
+        when(userService.findCurrentUser()).thenReturn(nonAdminUser);
+
+        // Act & Assert
+        assertThrows(AccessDeniedException.class, () ->
+            moderationService.getUserStrikes(regularUserId)
+        );
+    }
+
+    // ================= HELPER METHODS =================
+
+    private Strike createStrike(User issuedBy, RegularUser user, String reason) {
+        Strike strike = new Strike();
+        strike.setId(UUID.randomUUID());
+        strike.setIssuedBy(issuedBy);
+        strike.setUser(user);
+        strike.setReason(reason);
+        strike.setIssuedAt(LocalDateTime.now());
+        return strike;
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -18,3 +18,5 @@ spring.mail.port=2525
 
 # Avoid Actuator mail health contributor requiring mail sender map during tests
 management.health.mail.enabled=false
+
+sendgrid.api-key=dummy-key-for-tests


### PR DESCRIPTION
Admin Moderation System
Admins can now issue strikes to users, delete accounts, and users are notified via email when their account is deleted.

Features

Strikes: Issue moderation strikes with reason/description
Account Deletion: Delete user accounts with confirmation; auto-cleanup of related data
Email Notifications: Automated email sent on account deletion via SendGrid
Admin UI: Strike badges, warning button, confirmation dialogs

Security

Moderation endpoints require [ADMIN] authority
Admins cannot delete themselves
Deletion requires explicit confirmation