### PR TITLE
feat: switch solo filtra preguntas

### DIFF
--- a/frontend/src/features/home/ui/HomeScreen.js
+++ b/frontend/src/features/home/ui/HomeScreen.js
@@ -408,7 +408,8 @@ export default function HomeScreen({ navigation }) {
 
                     <View style={styles.mapWrapper}>
                         <MapComponent
-                            questions={showQuestions ? questions : []}
+                            questions={questions}
+                            showQuestions={showQuestions}
                             onQuestionPress={(qId) =>
                                 navigation.navigate('QuestionThread', { questionId: qId })
                             }
@@ -722,14 +723,15 @@ const styles = StyleSheet.create({
         paddingHorizontal: 20,
         flexDirection: 'row',
         alignItems: 'center',
+        justifyContent: 'flex-end',
         borderTopWidth: 1,
         borderTopColor: '#e5e7eb',
     },
     toggleLabel: {
-        flex: 1,
         fontSize: 14,
         fontWeight: '600',
         color: '#a52019',
+        marginRight: 12,
     },
     fab: {
         position: 'absolute',

--- a/frontend/src/features/home/ui/components/MapComponent.js
+++ b/frontend/src/features/home/ui/components/MapComponent.js
@@ -105,7 +105,7 @@ const getQuestionCoords = (q) => {
     return { lat, lng };
 };
 
-export default function MapComponent({ questions = [], onQuestionPress, onLocationChange, onPermissionChange }) {
+export default function MapComponent({ questions = [], onQuestionPress, onLocationChange, onPermissionChange, showQuestions = true }) {
     const [location, setLocation] = useState(null);
     const [publicLocations, setPublicLocations] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -223,6 +223,12 @@ export default function MapComponent({ questions = [], onQuestionPress, onLocati
     useEffect(() => {
         const ahora = new Date().getTime();
 
+        // Si showQuestions es false, retornar array vacío
+        if (!showQuestions) {
+            setVisibleQuestions([]);
+            return;
+        }
+
         // Filtramos las preguntas que ya vencieron antes de guardarlas en el estado
         const preguntasActivas = questions.filter((q) => {
             const fechaExpiracion = new Date(q.expiresAt).getTime();
@@ -230,7 +236,7 @@ export default function MapComponent({ questions = [], onQuestionPress, onLocati
         });
 
         setVisibleQuestions(preguntasActivas);
-    }, [questions]);
+    }, [questions, showQuestions]);
 
     const handleQuestionExpire = (questionId) => {
         setVisibleQuestions((prev) => prev.filter((q) => q.id !== questionId));


### PR DESCRIPTION
He cambiado el switch para que solo haga desaparecer las preguntas, es decir, los eventos siguen apareciendo en el mapa. También he unificado el componente ya que antes estaba por un lado el texto  y por otro el swicth. He probado metiendo eventos manualmente en bd ya que hasta ahora no se ha implementado dicha funcionalidad entera. 