### PR TITLE
feat: reward coins on like threshold with one-time payout

### DIFF
--- a/src/main/java/com/streetask/app/answer/AnswerRepository.java
+++ b/src/main/java/com/streetask/app/answer/AnswerRepository.java
@@ -4,9 +4,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.streetask.app.model.Answer;
 
@@ -40,5 +42,9 @@ public interface AnswerRepository extends CrudRepository<Answer, UUID> {
 	List<Object[]> aggregateVotesByUserIds(Collection<UUID> userIds);
 
 	long countByUserId(UUID userId);
+
+	@Modifying
+	@Query("UPDATE Answer a SET a.rewardClaimed = true WHERE a.id = :answerId AND (a.rewardClaimed = false OR a.rewardClaimed IS NULL)")
+	int markRewardClaimedIfUnclaimed(@Param("answerId") UUID answerId);
 
 }

--- a/src/main/java/com/streetask/app/answer/AnswerService.java
+++ b/src/main/java/com/streetask/app/answer/AnswerService.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.PageRequest;
@@ -23,12 +24,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.streetask.app.exceptions.ResourceNotFoundException;
+import com.streetask.app.functionalities.notifications.model.Notification;
+import com.streetask.app.functionalities.notifications.model.NotificationRepository;
+import com.streetask.app.functionalities.notifications.model.NotificationType;
 import com.streetask.app.functionalities.notifications.events.AnswerCreatedEvent;
 import com.streetask.app.model.Answer;
 import com.streetask.app.model.AnswerVote;
+import com.streetask.app.model.CoinTransaction;
 import com.streetask.app.model.GeoPoint;
 import com.streetask.app.model.Question;
+import com.streetask.app.model.enums.CoinTransactionType;
 import com.streetask.app.model.enums.VoteType;
+import com.streetask.app.model.CoinTransactionRepository;
 import com.streetask.app.user.RegularUser;
 import com.streetask.app.user.RegularUserRepository;
 
@@ -44,14 +51,25 @@ public class AnswerService {
 	private final AnswerVoteRepository answerVoteRepository;
 	private final RegularUserRepository regularUserRepository;
 	private final ApplicationEventPublisher eventPublisher;
+	private final CoinTransactionRepository coinTransactionRepository;
+	private final NotificationRepository notificationRepository;
+
+	@Value("${streetask.coins.answer-reward.like-threshold:${STREETASK_ANSWER_REWARD_LIKE_THRESHOLD:3}}")
+	private int answerRewardLikeThreshold = 3;
+
+	@Value("${streetask.coins.answer-reward.amount:${STREETASK_ANSWER_REWARD_AMOUNT:15}}")
+	private int answerRewardAmount = 15;
 
 	@Autowired
 	public AnswerService(AnswerRepository answerRepository, AnswerVoteRepository answerVoteRepository,
-			RegularUserRepository regularUserRepository, ApplicationEventPublisher eventPublisher) {
+			RegularUserRepository regularUserRepository, ApplicationEventPublisher eventPublisher,
+			CoinTransactionRepository coinTransactionRepository, NotificationRepository notificationRepository) {
 		this.answerRepository = answerRepository;
 		this.answerVoteRepository = answerVoteRepository;
 		this.regularUserRepository = regularUserRepository;
 		this.eventPublisher = eventPublisher;
+		this.coinTransactionRepository = coinTransactionRepository;
+		this.notificationRepository = notificationRepository;
 	}
 
 	@Transactional
@@ -153,8 +171,15 @@ public class AnswerService {
 	public Answer updateVotes(UUID answerId, UUID userId, VoteType voteType) {
 		Answer answer = findAnswer(answerId);
 		RegularUser answerOwner = answer.getUser();
+		if (answerOwner != null && answerOwner.getId() != null && answerOwner.getId().equals(userId)) {
+			throw new IllegalArgumentException("Users cannot like or dislike their own answers");
+		}
+
+		RegularUser voter = regularUserRepository.findById(userId)
+				.orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
 
 		Optional<AnswerVote> existingOpt = answerVoteRepository.findByUserIdAndAnswerId(userId, answerId);
+		boolean likeAdded = false;
 
 		if (existingOpt.isPresent()) {
 			AnswerVote existing = existingOpt.get();
@@ -168,6 +193,7 @@ public class AnswerService {
 				answer.setDownvotes(Math.max(0, answer.getDownvotes() - 1));
 				decrementDislikes(answerOwner);
 				incrementLikes(answerOwner);
+				likeAdded = true;
 			} else {
 				answer.setDownvotes(answer.getDownvotes() + 1);
 				answer.setUpvotes(Math.max(0, answer.getUpvotes() - 1));
@@ -178,24 +204,28 @@ public class AnswerService {
 			existing.setVotedAt(LocalDateTime.now());
 			answerVoteRepository.save(existing);
 		} else {
-			RegularUser user = regularUserRepository.findById(userId)
-					.orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
 			AnswerVote vote = new AnswerVote();
 			vote.setAnswer(answer);
-			vote.setUser(user);
+			vote.setUser(voter);
 			vote.setVoteType(voteType);
 			vote.setVotedAt(LocalDateTime.now());
 			answerVoteRepository.save(vote);
 			if (voteType == VoteType.LIKE) {
 				answer.setUpvotes(answer.getUpvotes() + 1);
 				incrementLikes(answerOwner);
+				likeAdded = true;
 			} else {
 				answer.setDownvotes(answer.getDownvotes() + 1);
 				incrementDislikes(answerOwner);
 			}
 		}
 
-		return answerRepository.save(answer);
+		Answer savedAnswer = answerRepository.save(answer);
+		if (likeAdded) {
+			savedAnswer = tryGrantLikeMilestoneReward(savedAnswer);
+		}
+
+		return savedAnswer;
 	}
 
 	@Transactional
@@ -300,6 +330,55 @@ public class AnswerService {
 		if (answer.getDownvotes() == null) {
 			answer.setDownvotes(0);
 		}
+		if (answer.getRewardClaimed() == null) {
+			answer.setRewardClaimed(false);
+		}
+	}
+
+	private Answer tryGrantLikeMilestoneReward(Answer answer) {
+		if (Boolean.TRUE.equals(answer.getRewardClaimed()) || answer.getUser() == null) {
+			return answer;
+		}
+
+		int currentLikes = answer.getUpvotes() == null ? 0 : answer.getUpvotes();
+		if (currentLikes < answerRewardLikeThreshold) {
+			return answer;
+		}
+
+		int claimedRows = answerRepository.markRewardClaimedIfUnclaimed(answer.getId());
+		if (claimedRows == 0) {
+			return answer;
+		}
+
+		RegularUser owner = answer.getUser();
+		int balanceBefore = owner.getCoinBalance() == null ? 0 : owner.getCoinBalance();
+		int balanceAfter = balanceBefore + answerRewardAmount;
+		owner.setCoinBalance(balanceAfter);
+
+		int earned = answer.getCoinsEarned() == null ? 0 : answer.getCoinsEarned();
+		answer.setCoinsEarned(earned + answerRewardAmount);
+		answer.setRewardClaimed(true);
+
+		CoinTransaction coinTransaction = new CoinTransaction();
+		coinTransaction.setUser(owner);
+		coinTransaction.setType(CoinTransactionType.EARN);
+		coinTransaction.setAmount(answerRewardAmount);
+		coinTransaction.setBalanceBefore(balanceBefore);
+		coinTransaction.setBalanceAfter(balanceAfter);
+		coinTransaction.setReferenceId(answer.getId());
+		coinTransaction.setCreatedAt(LocalDateTime.now());
+		coinTransactionRepository.save(coinTransaction);
+
+		Notification notification = new Notification();
+		notification.setUser(owner);
+		notification.setType(NotificationType.ANSWER_TO_QUESTION);
+		notification.setContent("Your answer helped a lot of people! You earned +" + answerRewardAmount + " coins.");
+		notification.setReferenceId(answer.getId());
+		notification.setReferenceType("ANSWER_REWARD");
+		notification.setSentAt(LocalDateTime.now());
+		notificationRepository.save(notification);
+
+		return answerRepository.save(answer);
 	}
 
 	private void attachAuthenticatedUser(Answer answer) {

--- a/src/main/java/com/streetask/app/model/Answer.java
+++ b/src/main/java/com/streetask/app/model/Answer.java
@@ -48,6 +48,8 @@ public class Answer extends BaseEntity {
     @PositiveOrZero(message = "Coins earned must be zero or positive")
     private Integer coinsEarned;
 
+    private Boolean rewardClaimed;
+
     @Embedded
     @Valid
     private GeoPoint userLocation;

--- a/src/main/java/com/streetask/app/model/CoinTransactionRepository.java
+++ b/src/main/java/com/streetask/app/model/CoinTransactionRepository.java
@@ -1,0 +1,8 @@
+package com.streetask.app.model;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoinTransactionRepository extends JpaRepository<CoinTransaction, UUID> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -85,5 +85,9 @@ streetask.web-push.subject=${STREETASK_WEB_PUSH_SUBJECT:mailto:streetask.notific
 streetask.web-push.public-key=${STREETASK_WEB_PUSH_PUBLIC_KEY:BCzmM4oFvgyIoji531RyMjAMxwSEcgRHivSvGBtDeP93MssCAQdfnZZlZ-24mpUMGlCRselBYpHj1onx9eHwqcQ}
 streetask.web-push.private-key=${STREETASK_WEB_PUSH_PRIVATE_KEY:xS6S6T2vAkW3mr43IsHOeb6J1DzkXA2AxcGn88z7uq8}
 
+# Answer reward balancing
+streetask.coins.answer-reward.like-threshold=${STREETASK_ANSWER_REWARD_LIKE_THRESHOLD:3}
+streetask.coins.answer-reward.amount=${STREETASK_ANSWER_REWARD_AMOUNT:15}
+
 #Mail
 sendgrid.api-key=${SENDGRID_API_KEY:}

--- a/src/main/resources/db/migration/V8__add_answer_reward_claimed_flag.sql
+++ b/src/main/resources/db/migration/V8__add_answer_reward_claimed_flag.sql
@@ -1,0 +1,6 @@
+ALTER TABLE answers
+    ADD COLUMN reward_claimed BIT(1) NOT NULL DEFAULT b'0';
+
+UPDATE answers
+SET reward_claimed = b'0'
+WHERE reward_claimed IS NULL;

--- a/src/test/java/com/streetask/app/answer/AnswerServiceTest.java
+++ b/src/test/java/com/streetask/app/answer/AnswerServiceTest.java
@@ -23,8 +23,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.streetask.app.exceptions.ResourceNotFoundException;
 import com.streetask.app.functionalities.notifications.events.AnswerCreatedEvent;
+import com.streetask.app.functionalities.notifications.model.NotificationRepository;
 import com.streetask.app.model.Answer;
 import com.streetask.app.model.AnswerVote;
+import com.streetask.app.model.CoinTransactionRepository;
 import com.streetask.app.model.GeoPoint;
 import com.streetask.app.model.Question;
 import com.streetask.app.model.enums.VoteType;
@@ -45,12 +47,19 @@ class AnswerServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private CoinTransactionRepository coinTransactionRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
     @InjectMocks
     private AnswerService answerService;
 
     private Answer answer;
     private Question question;
     private RegularUser authenticatedUser;
+    private RegularUser answerOwner;
     private RegularUser regularUser;
     private UUID answerId;
     private UUID questionId;
@@ -80,6 +89,10 @@ class AnswerServiceTest {
         when(regularUserRepository.findByUserNameIgnoreCase(authenticatedUser.getEmail()))
                 .thenReturn(Optional.empty());
 
+        answerOwner = new RegularUser();
+        answerOwner.setId(UUID.randomUUID());
+        answerOwner.setCoinBalance(0);
+
         // Create test question with location and radius
         question = new Question();
         question.setId(questionId);
@@ -97,15 +110,20 @@ class AnswerServiceTest {
         answer.setId(answerId);
         answer.setQuestion(question);
         answer.setContent("Test Answer");
-        answer.setUser(authenticatedUser);
+        answer.setUser(answerOwner);
         answer.setUserLocation(new GeoPoint());
         answer.getUserLocation().setLatitude(37.7749); // Same location as question
         answer.getUserLocation().setLongitude(-122.4194);
         answer.setUpvotes(0);
         answer.setDownvotes(0);
+        answer.setRewardClaimed(false);
 
         regularUser = new RegularUser();
         regularUser.setId(userId);
+        regularUser.setCreatedAt(LocalDateTime.now().minusDays(60));
+        regularUser.setActive(true);
+
+        when(regularUserRepository.findById(userId)).thenReturn(Optional.of(regularUser));
     }
 
     @AfterEach
@@ -436,7 +454,6 @@ class AnswerServiceTest {
 
         when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
         when(answerVoteRepository.findByUserIdAndAnswerId(userId, answerId)).thenReturn(Optional.empty());
-        when(regularUserRepository.findById(userId)).thenReturn(Optional.of(regularUser));
         when(answerRepository.save(answer)).thenReturn(answer);
 
         Answer result = answerService.updateVotes(answerId, userId, VoteType.LIKE);
@@ -454,7 +471,6 @@ class AnswerServiceTest {
 
         when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
         when(answerVoteRepository.findByUserIdAndAnswerId(userId, answerId)).thenReturn(Optional.empty());
-        when(regularUserRepository.findById(userId)).thenReturn(Optional.of(regularUser));
         when(answerRepository.save(answer)).thenReturn(answer);
 
         Answer result = answerService.updateVotes(answerId, userId, VoteType.DISLIKE);
@@ -530,6 +546,58 @@ class AnswerServiceTest {
 
         verify(answerRepository, times(1)).findById(answerId);
         verify(answerRepository, never()).save(any(Answer.class));
+    }
+
+    @Test
+    void testUpdateVotesRejectsSelfVote() {
+        answer.setUser(authenticatedUser);
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> answerService.updateVotes(answerId, userId, VoteType.LIKE));
+
+        verify(answerVoteRepository, never()).save(any(AnswerVote.class));
+        verify(answerRepository, never()).save(any(Answer.class));
+    }
+
+    @Test
+    void testUpdateVotesRewardsOwnerWhenThresholdReached() {
+        answer.setUpvotes(2);
+        answer.setDownvotes(0);
+        answerOwner.setCoinBalance(10);
+
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+        when(answerVoteRepository.findByUserIdAndAnswerId(userId, answerId)).thenReturn(Optional.empty());
+        when(answerRepository.markRewardClaimedIfUnclaimed(answerId)).thenReturn(1);
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer result = answerService.updateVotes(answerId, userId, VoteType.LIKE);
+
+        assertEquals(3, result.getUpvotes());
+        assertTrue(result.getRewardClaimed());
+        assertEquals(25, answerOwner.getCoinBalance());
+        assertEquals(15, result.getCoinsEarned());
+        verify(coinTransactionRepository, times(1)).save(any());
+        verify(notificationRepository, times(1)).save(any());
+        verify(answerRepository, times(2)).save(answer);
+    }
+
+    @Test
+    void testUpdateVotesDoesNotDuplicateRewardWhenAlreadyClaimedConcurrently() {
+        answer.setUpvotes(2);
+        answer.setRewardClaimed(false);
+        answerOwner.setCoinBalance(10);
+
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+        when(answerVoteRepository.findByUserIdAndAnswerId(userId, answerId)).thenReturn(Optional.empty());
+        when(answerRepository.markRewardClaimedIfUnclaimed(answerId)).thenReturn(0);
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        answerService.updateVotes(answerId, userId, VoteType.LIKE);
+
+        assertEquals(10, answerOwner.getCoinBalance());
+        verify(coinTransactionRepository, never()).save(any());
+        verify(notificationRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
- move coin reward trigger from answer creation to vote updates
- prevent users from voting on their own answers
- add idempotent reward claim to avoid duplicate payouts
- create coin transaction and in-app notification on reward
- add configurable reward amount and like threshold

Closes #483 