### PR TITLE
feat: add verifiedBusinessAccounts field and seed admin profile in database

### DIFF
--- a/src/main/java/com/streetask/app/user/Admin.java
+++ b/src/main/java/com/streetask/app/user/Admin.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.streetask.app.model.Report;
 import com.streetask.app.business.BusinessAccount;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -30,8 +31,10 @@ public class Admin extends User {
     private LocalDateTime assignedAt;
 
     @OneToMany(mappedBy = "resolvedBy")
+    @JsonIgnore
     private List<Report> resolvedReports;
 
     @OneToMany(mappedBy = "verifiedBy")
+    @JsonIgnore
     private List<BusinessAccount> verifiedBusinessAccounts;
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -30,6 +30,15 @@ VALUES (
     '11111111-1111-1111-1111-111111111111'
 );
 
+-- Admin profile row required by JOINED inheritance (User -> Admin)
+INSERT INTO admins (id, role, permissions, assigned_at)
+VALUES (
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    'SUPER_ADMIN',
+    '{"canModerate": true, "canManageUsers": true}',
+    CURRENT_TIMESTAMP
+);
+
 -- Regular user: user1@streetask.com / password: 4dm1n
 -- MySQL/Aiven manual script in DBeaver:
 -- INSERT INTO appusers (id, email, user_name, password, first_name, last_name, authority, account_type, active, created_at)

--- a/src/test/java/com/streetask/app/business/BusinessAccountCreationUnitTest.java
+++ b/src/test/java/com/streetask/app/business/BusinessAccountCreationUnitTest.java
@@ -3,8 +3,8 @@ package com.streetask.app.business;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -109,7 +109,7 @@ class BusinessAccountCreationUnitTest {
         request.setCompanyName("StreetAsk Business");
         request.setAddress("Main Street 123");
 
-        when(userService.existsUser("business.ok@streetask.com")).thenReturn(true);
+        when(authService.isPendingBasicSignup("business.ok@streetask.com")).thenReturn(true);
         when(businessAccountRepository.existsByTaxId("B12345670")).thenReturn(false);
 
         ResponseEntity<MessageResponse> response = authController.completeBusinessUser(request);
@@ -143,7 +143,7 @@ class BusinessAccountCreationUnitTest {
         request.setTaxId("b-1234 5678");
         request.setCompanyName("StreetAsk Duplicated");
 
-        when(userService.existsUser("business.dup@streetask.com")).thenReturn(true);
+        when(authService.isPendingBasicSignup("business.dup@streetask.com")).thenReturn(true);
         when(businessAccountRepository.existsByTaxId("B12345678")).thenReturn(true);
 
         ResponseEntity<MessageResponse> response = authController.completeBusinessUser(request);
@@ -151,7 +151,8 @@ class BusinessAccountCreationUnitTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getMessage()).isEqualTo("Error: Tax ID is already registered!");
-        verifyNoInteractions(authService);
+        verify(authService).isPendingBasicSignup("business.dup@streetask.com");
+        verify(authService, never()).convertToBusinessUser(any(BusinessSignupRequest.class));
     }
 
     @Test
@@ -183,6 +184,11 @@ class BusinessAccountCreationUnitTest {
         basicUser.setFirstName("Pending");
         basicUser.setLastName("Owner");
         basicUser.setCreatedAt(LocalDateTime.of(2026, 4, 8, 12, 0));
+        basicUser.setActive(false);
+
+        Authorities basicAuthority = new Authorities();
+        basicAuthority.setAuthority("USER");
+        basicUser.setAuthority(basicAuthority);
 
         Authorities businessAuthority = new Authorities();
         businessAuthority.setAuthority("BUSINESS");


### PR DESCRIPTION
This pull request makes improvements to how the `Admin` entity is serialized and ensures that the database has a corresponding admin profile row for inheritance mapping. The main changes are grouped into serialization improvements for the entity and database seeding for admin users.

**Serialization improvements:**

* Added the `@JsonIgnore` annotation to the `resolvedReports` and `verifiedBusinessAccounts` fields in the `Admin` class to prevent these potentially large or recursive relationships from being serialized in API responses.
* Imported `com.fasterxml.jackson.annotation.JsonIgnore` in `Admin.java` to support the new annotations.

**Database seeding:**

* Added an insert statement to `data.sql` to create a required row in the `admins` table, ensuring proper setup for the JOINED inheritance strategy between `User` and `Admin`.