### PR TITLE
docs: add cost projection and inventory documentation for pilot user growth

### DIFF
--- a/docs/Sprint 3/pilot-cost-forecast.md
+++ b/docs/Sprint 3/pilot-cost-forecast.md
@@ -1,0 +1,169 @@
+# Proyección de costes de infraestructura para crecimiento de usuarios piloto
+
+## 1. Objetivo
+Analizar y proyectar los costes de infraestructura a medida que aumenta el número de usuarios piloto, incluyendo escenarios de escalabilidad y patrones de uso previstos para anticipar gastos futuros.
+
+## 2. Alcance de la proyección
+Este informe estima el coste mensual de operación para fases de adopción progresiva:
+- 50 usuarios activos (piloto inicial cercano al volumen actual)
+- 250 usuarios activos (piloto ampliado)
+- 500 usuarios activos (piloto extendido)
+- 1.000 usuarios activos (escenario de tension/pre-produccion)
+
+La estimacion cubre:
+- Backend en contenedores
+- Base de datos MySQL gestionada
+- Hosting web del frontend
+- Notificaciones en tiempo real (WebSocket)
+- Push notifications web
+- Integraciones externas (Stripe, email, geocodificación)
+- Costes operativos asociados (logs/egress/CI-CD)
+
+## 3. Supuestos de uso
+Para estimar costes se usan supuestos conservadores de pilotaje:
+
+1. Actividad de usuarios
+- Usuarios activos diarios (DAU) aproximados: 30% de los usuarios activos mensuales
+- Sesiones por usuario activo diario: 2-3 por día
+- Peticiones API por usuario activo diario: 60-90
+
+2. Uso funcional principal
+- Lectura frecuente de preguntas/respuestas y ubicaciones
+- Escrituras por creación de preguntas/respuestas, votos y ubicaciones
+- Notificaciones por eventos (preguntas cercanas y actividad en respuestas)
+
+3. Tiempo real
+- Conexión WebSocket activa para usuarios autenticados
+- Reconexión automática del cliente en caídas de red
+
+4. Escenario tecnológico
+- Producción sobre MySQL + backend en contenedor
+- Frontend web desplegado en EAS
+- Sin CDN dedicada (red de distribución de contenido) y sin broker externo en fase piloto
+
+## 4. Patrones de uso que impactan el coste
+
+### 4.1 Mucha lectura de datos
+- Consulta de feed, filtros y listados de contenido.
+- Consulta de ubicaciones públicas recientes.
+- Este patrón aumenta el uso de proceso del servidor y de operaciones de disco en la base de datos.
+
+### 4.2 Muchas escrituras de datos
+- Publicación de ubicación del usuario.
+- Registro de votos y transacciones de monedas.
+- Inserciones de notificaciones y eventos de actividad.
+- Este patrón incrementa las operaciones de guardado en la base de datos y el crecimiento del histórico almacenado.
+
+### 4.3 Uso de red y envíos a múltiples usuarios
+- WebSockets persistentes por usuario conectado.
+- En eventos de alta actividad, una acción puede notificar a varios receptores al mismo tiempo (fan-out).
+- Incrementa el consumo de memoria, red y tráfico saliente hacia internet (egress).
+
+### 4.4 Proceso automático que se ejecuta cada minuto
+- El sistema revisa cada minuto qué preguntas ya han caducado.
+- Esas preguntas se marcan como inactivas automáticamente.
+- Este proceso genera carga constante en la base de datos, incluso con poco tráfico de usuarios.
+
+## 5. Proyección de costes mensuales (estimada y trazable)
+
+## 5.1 Resumen por volumen de usuarios activos
+| Escenario | Coste mensual estimado |
+|---|---:|
+| 50 usuarios activos | 15-35 EUR |
+| 250 usuarios activos | 30-70 EUR |
+| 500 usuarios activos | 45-110 EUR |
+| 1.000 usuarios activos | 80-190 EUR |
+
+## 5.2 Desglose aproximado por componente
+| Componente | 50 usuarios | 250 usuarios | 500 usuarios | 1.000 usuarios |
+|---|---:|---:|---:|---:|
+| Compute backend | 5-12 EUR | 10-24 EUR | 15-36 EUR | 30-70 EUR |
+| MySQL gestionado | 5-10 EUR | 10-20 EUR | 15-35 EUR | 25-60 EUR |
+| Frontend hosting web | 2-5 EUR | 4-10 EUR | 6-15 EUR | 10-25 EUR |
+| Logs, egress y observabilidad | 2-5 EUR | 3-10 EUR | 5-15 EUR | 10-25 EUR |
+| Email/push/CI-CD (base) | 1-3 EUR | 3-6 EUR | 4-9 EUR | 5-10 EUR |
+| **Total estimado** | **15-35 EUR** | **30-70 EUR** | **45-110 EUR** | **80-190 EUR** |
+
+Nota: Stripe se considera aparte como coste variable por transacción.
+Nota 2: en contexto académico con créditos o planes gratuitos, el coste efectivo puede ser inferior en fases tempranas.
+Nota 3: estos importes son costes mensuales totales de la infraestructura para cada escenario, no coste por usuario individual.
+
+## 5.3 Impacto de Stripe (variable)
+Fórmula aproximada por pago:
+- 2,9% + 0,30 EUR por transaccion
+
+Ejemplo con suscripción de 19,99 EUR:
+- Comisión aproximada por cobro: 0,88 EUR
+- 50 cobros/mes: ~44 EUR en comisiones Stripe
+- 200 cobros/mes: ~176 EUR en comisiones Stripe
+
+## 6. Escenarios de escalabilidad y puntos no lineales
+
+## 6.1 Escenario A: 50 usuarios activos (piloto inicial)
+- Infraestructura mínima viable.
+- Escalado generalmente lineal.
+- Riesgo bajo de cuellos de botella.
+
+## 6.2 Escenario B: 250 usuarios activos (piloto ampliado)
+- Empieza a tensionarse la base de datos en picos.
+- WebSocket y notificaciones elevan el consumo de memoria y red.
+- Primeros saltos de nivel de servicio posibles en base de datos o compute.
+
+## 6.3 Escenario C: 500 usuarios activos (piloto extendido)
+- Mayor probabilidad de coste no lineal por:
+  - salto de nivel de servicio de MySQL
+  - necesidad de mayor capacidad en contenedor backend
+  - mayor coste de egress y logs
+- Conviene preparar optimizaciones estructurales.
+
+## 6.4 Escenario D: 1.000 usuarios activos (preproducción)
+- Incremento notable de concurrencia en tiempo real.
+- Mayor probabilidad de necesitar redimensionado conjunto de compute y base de datos.
+- Recomendable validar límites de arquitectura antes de este umbral.
+
+## 6.5 Dónde deja de ser lineal el coste
+1. Base de datos:
+- El paso de un nivel de servicio básico a uno superior suele implicar un aumento de precio significativo.
+
+2. Tiempo real:
+- Con muchas conexiones WebSocket concurrentes, una sola replica puede no ser suficiente.
+- Escalar horizontalmente con broker en memoria complica la consistencia y la operación.
+
+3. Integraciones externas:
+- Geocodificación y pagos crecen por evento, no solo por usuario.
+- Campañas o picos de uso pueden aumentar los costes por encima de lo esperado.
+
+## 7. Riesgos de desviación presupuestaria
+1. DAU mayor al previsto.
+2. Más acciones por usuario (votos, respuestas, notificaciones) de las modeladas.
+3. Incremento de retención de datos sin políticas de limpieza.
+4. Picos de tráfico con reconexiones WebSocket más frecuentes.
+
+## 8. Recomendaciones de control
+1. Definir presupuesto mensual tope por entorno y alertas de gasto.
+2. Medir de forma continua:
+- coste total mensual
+- coste por usuario activo
+- coste por 1.000 requests
+3. Revisar periódicamente tareas programadas y consultas más costosas.
+4. Planificar umbrales de escalado (DB/compute) antes de alcanzarlos.
+5. Revisar trimestralmente el proveedor y el nivel de servicio para optimización de coste-rendimiento.
+
+## 9. Conclusiones
+- El coste inicial del piloto es contenido, pero crece rápidamente al aumentar la concurrencia y el tiempo real.
+- El principal factor de gasto en crecimiento es la base de datos MySQL junto con el backend.
+- A partir de 250-500 usuarios activos pueden aparecer primeros saltos de coste no lineales.
+- La visibilidad temprana de métricas financieras y técnicas es clave para evitar sobrecostes.
+
+## Anexo A. Glosario
+- DAU: usuarios activos diarios.
+- CPU: capacidad de proceso del servidor.
+- CDN: red de servidores que acelera la entrega de contenido (imágenes, JS, CSS).
+- IOPS: número de operaciones de lectura/escritura por segundo en disco o base de datos.
+- Egress: tráfico de salida desde tu infraestructura hacia internet.
+- Nivel de servicio: plan o nivel contratado con un proveedor cloud.
+- Fee: comisión o tarifa aplicada a un cobro.
+- Lectura intensiva: predominan consultas de lectura.
+- Escritura frecuente: predominan operaciones de guardado o actualización.
+- Fan-out: una acción genera envíos a varios usuarios a la vez.
+- Concurrencia: número de usuarios o procesos activos al mismo tiempo.

--- a/docs/Sprint 3/service-cost-inventory.md
+++ b/docs/Sprint 3/service-cost-inventory.md
@@ -1,0 +1,183 @@
+# Inventario de costes operativos actuales por servicio
+
+## 1. Objetivo
+Identificar y documentar todos los costes de servicio actuales (alojamiento, base de datos, APIs de terceros, etc.) para ofrecer una visión clara de los gastos operativos del proyecto.
+
+## 2. Metodología de inventario
+Se clasifican los servicios por categoría de coste:
+1. Compute/hosting
+2. Base de datos
+3. Hosting web y red
+4. APIs de terceros
+5. Mensajería y notificaciones
+6. CI/CD y registro de imágenes
+7. Costes indirectos operativos
+
+Para cada servicio se documenta:
+- Función técnica
+- Tipo de coste (fijo o variable)
+- Principal motor de consumo
+- Riesgo de aumento de factura
+
+## 2.1 Base económica y trazabilidad del documento
+Para evitar estimaciones arbitrarias, este inventario se apoya en fuentes internas del proyecto:
+
+1. Costes históricos reportados
+- docs/Sprint 1/estimation_costs.md documenta costes de despliegue en Azure por sprint (17,50 EUR; 35,00 EUR; 52,50 EUR) y un total acumulado de infraestructura de 122,50 EUR en el periodo analizado.
+
+2. Contexto de operación en fase MVP/piloto
+- docs/Sprint 0/Pricing.md indica uso de planes gratuitos y créditos en la fase inicial, y una proyección de infraestructura de ~500 EUR/mes para 10.000 usuarios.
+
+3. Volumen de pilotos documentado
+- docs/Sprint 2/deliverables/10-S2-pilot-users.md registra 65 usuarios piloto, que sirve como referencia para el tramo inicial de operación.
+
+Conclusión de trazabilidad:
+- Los costes actuales reflejan un entorno de bajo gasto por créditos y planes gratuitos.
+- Las proyecciones de crecimiento se interpretan como escenarios de planificación, no como factura cerrada de proveedor.
+
+## 3. Inventario de servicios y coste asociado
+
+### 3.1 Compute y hosting backend
+Servicio: Backend Spring Boot en contenedor
+- Función: API REST, seguridad JWT, lógica de negocio y notificaciones.
+- Tipo de coste: Mixto (capacidad base + variable por uso).
+- Principal motor de coste:
+  - capacidad de proceso (CPU) y memoria por petición
+  - conexiones activas de usuarios
+  - tareas automáticas y envíos de notificaciones a varios usuarios a la vez
+- Riesgo de sobrecoste: medio/alto en crecimiento de concurrencia.
+
+### 3.2 Base de datos
+Servicio: MySQL gestionado (producción), H2 en desarrollo y pruebas
+- Función: Persistencia transaccional de usuarios, preguntas, respuestas, votos, notificaciones, ubicaciones y suscripciones.
+- Tipo de coste: Mixto (nivel de servicio base + almacenamiento, copias de seguridad y operaciones por proveedor).
+- Principal motor de coste:
+  - volumen de lectura y escritura
+  - crecimiento de tablas históricas
+  - tareas automáticas programadas y consultas de listados
+- Riesgo de sobrecoste: alto al subir de nivel de servicio.
+
+### 3.3 Hosting web
+Servicio: EAS Hosting para la web de Expo
+- Función: alojamiento de la app web.
+- Tipo de coste: Mixto (plan base + consumo de tráfico y artefactos según plan).
+- Principal motor de coste:
+  - tráfico de usuarios
+  - despliegues frecuentes
+- Riesgo de sobrecoste: medio en periodos de pruebas intensivas.
+
+### 3.4 APIs y servicios de terceros
+
+#### Stripe
+- Función: proceso de pago y confirmación de la suscripción de negocio.
+- Tipo de coste: variable por transacción.
+- Principal motor de coste: número de cobros exitosos.
+- Riesgo: directamente proporcional al volumen de suscripciones.
+
+#### Email transaccional
+- Función: envío de correos (SMTP y/o SendGrid).
+- Tipo de coste: generalmente variable por volumen.
+- Principal motor de coste: número de correos enviados.
+- Riesgo: bajo en fase piloto si no hay campañas masivas.
+
+#### OpenStreetMap/Nominatim
+- Función: mapas y búsqueda de direcciones.
+- Tipo de coste: puede ser cero en uso comunitario, pero con limitaciones de política de uso y servicio.
+- Principal motor de coste: número de cargas de mapa y búsquedas de dirección.
+- Riesgo: medio, por posible migración a un servicio de pago con garantía de servicio.
+
+### 3.5 Notificaciones y tiempo real
+
+#### Notificaciones en tiempo real dentro de la aplicación
+- Función: mensajes que aparecen al instante cuando ocurre una acción relevante en la app.
+- Tipo de coste: indirecto (consume capacidad del backend).
+- Principal motor de coste:
+  - conexiones activas
+  - reconexiones
+  - volumen de mensajes enviados
+- Riesgo: medio/alto en concurrencia elevada.
+
+#### Notificaciones push en el navegador
+- Función: avisos que llegan al navegador del usuario aunque no esté dentro de la app en ese momento.
+- Tipo de coste: indirecto (servidor, red y operaciones de base de datos).
+- Principal motor de coste:
+  - número de dispositivos
+  - envíos a varios usuarios por cada evento
+- Riesgo: medio por carga de envío y filtrado por distancia.
+
+### 3.6 CI/CD, compilación y registro de imágenes
+Servicios: GitHub Actions, Docker Hub y despliegues automatizados
+- Función: validación de calidad, pruebas, compilación y despliegue.
+- Tipo de coste:
+  - GitHub Actions: bajo o gratuito según límites o plan
+  - Docker Hub: plan base o profesional según uso
+- Principal motor de coste:
+  - frecuencia de pipelines
+  - compilaciones pesadas
+  - almacenamiento de imágenes
+- Riesgo: bajo/medio, normalmente controlable con buenas políticas de pipeline.
+
+### 3.7 Costes indirectos operativos
+1. Logs y observabilidad
+- Aumentan con el tráfico y la verbosidad.
+
+2. Tráfico de salida a internet
+- Sube con los datos que la plataforma envía a usuarios y dispositivos.
+
+3. Almacenamiento de histórico
+- Las tablas de notificaciones, ubicaciones, actividad y auditoría crecen con el uso.
+
+## 4. Matriz resumida de costes actuales
+| Categoría | Servicio | Estado actual | Tipo de coste | Principal motor |
+|---|---|---|---|---|
+| Hosting backend | Contenedor Spring Boot | Activo | Mixto | CPU, memoria, conexiones activas |
+| Base de datos | MySQL (prod) / H2 (dev) | Activo | Mixto | Operaciones de lectura/escritura |
+| Hosting web | EAS web | Activo | Mixto | Tráfico y despliegues |
+| Pagos | Stripe | Activo | Variable | Transacciones |
+| Correo | Brevo SMTP / SendGrid | Activo | Variable | Correos enviados |
+| Mapas y búsquedas | OSM + Nominatim | Activo | Variable indirecto | Cargas de mapa y búsquedas |
+| Tiempo real | Notificaciones en la app + push en el navegador | Activo | Indirecto | Concurrencia y envíos a varios usuarios |
+| CI/CD | GitHub Actions + Docker Hub | Activo | Bajo/mixto | Número de pipelines |
+
+## 4.1 Costes actuales documentados en el proyecto
+| Concepto | Valor documentado | Fuente interna |
+|---|---:|---|
+| Coste de despliegue Azure Sprint 0 | 17,50 EUR | docs/Sprint 1/estimation_costs.md |
+| Coste de despliegue Azure Sprint 1 | 17,50 EUR | docs/Sprint 1/estimation_costs.md |
+| Coste de despliegue Azure Sprint 2 | 35,00 EUR | docs/Sprint 1/estimation_costs.md |
+| Coste de despliegue Azure Sprint 3 (estimado) | 52,50 EUR | docs/Sprint 1/estimation_costs.md |
+| Total infraestructura periodo analizado | 122,50 EUR | docs/Sprint 1/estimation_costs.md |
+| Coste actual en MVP con planes gratuitos/créditos | 0 EUR (operativo) | docs/Sprint 0/Pricing.md |
+| Referencia de infraestructura a escala (10k usuarios) | ~500 EUR/mes | docs/Sprint 0/Pricing.md |
+
+## 5. Principales generadores de gasto hoy
+1. Base de datos MySQL (lectura/escritura y nivel de servicio).
+2. Compute backend por uso de API y notificaciones en tiempo real.
+3. Costes variables de Stripe (si hay conversión de pagos).
+4. Tráfico de salida y registros al aumentar notificaciones y tráfico.
+
+## 6. Recomendaciones para gestión de gasto operativo
+1. Crear una hoja mensual de costes por categoría.
+2. Medir coste por usuario activo y coste por 1.000 requests.
+3. Definir alertas de presupuesto por servicio.
+4. Revisar retención de datos para contener almacenamiento.
+5. Evaluar cambios de nivel de servicio y optimizaciones antes de picos de uso.
+
+## 7. Conclusiones
+- Este inventario ofrece una visión clara de qué servicios generan gasto y cuál es su peso dentro del proyecto.
+- A partir de él se pueden priorizar las áreas que conviene vigilar primero: base de datos, backend y servicios de terceros.
+- El documento sirve como base para fijar presupuestos, definir alertas de gasto y planificar futuras mejoras de infraestructura.
+
+## Anexo A. Glosario
+- API: interfaz que permite que una parte del sistema se comunique con otra.
+- Backend: parte del sistema que procesa la lógica y guarda los datos.
+- CDN: red de servidores que acelera la entrega de contenido (imágenes, JS, CSS).
+- CPU: capacidad de proceso del servidor.
+- Créditos: saldo promocional o gratuito que ofrece un proveedor cloud.
+- DAU: usuarios activos diarios.
+- Egress: tráfico de salida desde la infraestructura hacia internet.
+- Fan-out: una acción genera envíos a varios usuarios al mismo tiempo.
+- IOPS: número de operaciones de lectura/escritura por segundo en disco o base de datos.
+- Nivel de servicio: plan o nivel contratado con un proveedor cloud.
+- Tarea programada: acción que se ejecuta automáticamente cada cierto tiempo sin que una persona la lance.
+- Tráfico de salida: datos que salen del servidor hacia los usuarios.


### PR DESCRIPTION
This pull request adds two new documentation files focused on the analysis and transparency of infrastructure and service costs for the project. The first document provides a detailed projection of infrastructure costs as the number of pilot users grows, while the second inventories current operational costs by service, offering a clear overview of where and how resources are being spent.

**Infrastructure cost projection and analysis:**

* Added `pilot-cost-forecast.md` with a comprehensive forecast of monthly infrastructure costs for different user growth scenarios (50, 250, 500, and 1,000 active users), including breakdowns by backend, database, frontend hosting, notifications, and integrations. The document highlights patterns of usage that impact costs, identifies non-linear scaling points, and provides recommendations for cost control.

**Current service cost inventory:**

* Added `service-cost-inventory.md` documenting all current operational costs by service (compute/hosting, database, web hosting, third-party APIs, notifications, CI/CD, and indirect costs). The document includes a matrix summarizing costs, main cost drivers, risks, and recommendations for ongoing cost management and monitoring.