### PR TITLE
Feature/limit questions

### DIFF
--- a/frontend/src/features/questions/ui/CreateQuestionScreen.js
+++ b/frontend/src/features/questions/ui/CreateQuestionScreen.js
@@ -84,6 +84,7 @@ export default function CreateQuestionScreen({ navigation }) {
   const [userLng, setUserLng] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [focusedField, setFocusedField] = useState(null);
+  const [todayQuestionCount, setTodayQuestionCount] = useState(0);
   // const [showFakeAd, setShowFakeAd] = useState(false);
   // const [adSecondsLeft, setAdSecondsLeft] = useState(FAKE_AD_DURATION_SECONDS);
   // const [queuedPayload, setQueuedPayload] = useState(null);
@@ -161,6 +162,26 @@ export default function CreateQuestionScreen({ navigation }) {
   useEffect(() => {
     let isMounted = true;
 
+    const loadTodayQuestionCount = async () => {
+      if (!user?.id) return;
+      try {
+        const response = await apiClient.get('/api/v1/questions/today-count');
+        if (!isMounted) return;
+        setTodayQuestionCount(response?.data ?? 0);
+      } catch (e) {
+        console.warn('Unable to load today question count:', e?.message || e);
+      }
+    };
+
+    loadTodayQuestionCount();
+    return () => {
+      isMounted = false;
+    };
+  }, [user?.id]);
+
+  useEffect(() => {
+    let isMounted = true;
+
     const preloadCurrentLocation = async () => {
       const coords = await getCurrentPositionWeb();
       if (!isMounted || !coords) {
@@ -216,6 +237,7 @@ export default function CreateQuestionScreen({ navigation }) {
   const premiumRadiusValid = !isPremium || isPremiumRadiusValid(parsedRadiusMeters);
   const premiumHoursValid = !isPremium || isPremiumHoursValid(parsedHours);
   const showRadiusRangeError = isPremium && radiusInput.trim().length > 0 && !premiumRadiusValid;
+  const dailyLimitReached = !isPremium && todayQuestionCount >= 3;
 
   const canPost = useMemo(
     () =>
@@ -223,8 +245,9 @@ export default function CreateQuestionScreen({ navigation }) {
       content.trim() &&
       premiumRadiusValid &&
       premiumHoursValid &&
-      !isSubmitting,
-    [title, content, premiumRadiusValid, premiumHoursValid, isSubmitting]
+      !isSubmitting &&
+      !dailyLimitReached,
+    [title, content, premiumRadiusValid, premiumHoursValid, isSubmitting, dailyLimitReached]
   );
 
   const searchAddress = async () => {
@@ -662,9 +685,37 @@ export default function CreateQuestionScreen({ navigation }) {
                   <Text style={styles.timeChipText}>h</Text>
                 </View>
               ) : (
-                <Text style={styles.timeChipText}>Duration: 2h (fixed in free plan)</Text>
+                <View>
+                  <Text style={styles.timeChipText}>Duration: 2h (fixed in free plan)</Text>
+                  <Text style={styles.timeChipText}>Max 3 questions a day (fixed in free plan)</Text>
+                </View>
               )}
             </View>
+
+            {dailyLimitReached && (
+              <View style={styles.dailyLimitWarning}>
+                <Ionicons name="alert-circle" size={16} color="#dc2626" />
+                <View style={{ flex: 1, marginLeft: 10 }}>
+                  <Text style={styles.dailyLimitTitle}>Daily limit reached</Text>
+                  <Text style={styles.dailyLimitText}>
+                    You can create a maximum of 3 questions per day. You can add more
+                    by using the coins you gain while answering questions,
+                    or by upgrading to the premium plan.
+                  </Text>
+                </View>
+                <TouchableOpacity
+                  style={styles.shopBtn}
+                  onPress={() => {
+                    // Shop functionality to be implemented
+                    console.log('Shop button pressed');
+                  }}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.shopBtnText}>Shop</Text>
+                </TouchableOpacity>
+              </View>
+            )}
+            {/* TODO if (!isPremium && todayQuestionCount >= 3) {*/}
             {/* Legacy free-plan helper (disabled):
             {!isPremium ? (
               <Text style={styles.helperText}>
@@ -1053,4 +1104,40 @@ const styles = StyleSheet.create({
     color: '#9ca3af',
   },
   postBtnText: { fontWeight: '700', fontSize: 15, color: '#fff' },
+  dailyLimitWarning: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    backgroundColor: '#fee2e2',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#fecaca',
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    marginTop: 16,
+  },
+  dailyLimitTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#dc2626',
+    marginBottom: 2,
+  },
+  dailyLimitText: {
+    fontSize: 12,
+    color: '#991b1b',
+    lineHeight: 16,
+  },
+  shopBtn: {
+    backgroundColor: '#dc2626',
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  shopBtnText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#fff',
+  },
 });

--- a/src/main/java/com/streetask/app/question/QuestionRestController.java
+++ b/src/main/java/com/streetask/app/question/QuestionRestController.java
@@ -64,6 +64,12 @@ public class QuestionRestController {
 		return new ResponseEntity<>(questionService.findQuestion(id), HttpStatus.OK);
 	}
 
+	@GetMapping("/today-count")
+	public ResponseEntity<Long> getTodayQuestionCount() {
+		long count = questionService.getTodayQuestionCountForAuthenticatedUser();
+		return new ResponseEntity<>(count, HttpStatus.OK);
+	}
+
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public ResponseEntity<Question> create(@RequestBody @Valid Question question) {

--- a/src/main/java/com/streetask/app/question/QuestionService.java
+++ b/src/main/java/com/streetask/app/question/QuestionService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +50,22 @@ public class QuestionService {
 		this.regularUserRepository = regularUserRepository;
 		this.eventPublisher = eventPublisher;
 	}
+	public long questionsTodayCount(UUID creatorId) {
+		return StreamSupport.stream(questionRepository.findByCreatorId(creatorId).spliterator(), false)
+				.filter(q -> q.getCreatedAt().isAfter(LocalDateTime.now(ZoneId.of("UTC")).minusHours(24)))
+				.count();
+	}
+
+	@Transactional(readOnly = true)
+	public long getTodayQuestionCountForAuthenticatedUser() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		String email = auth.getName();
+		
+		RegularUser ru = regularUserRepository.findByEmail(email)
+				.orElseThrow(() -> new AccessDeniedException("Only regular users can check their question count"));
+		
+		return questionsTodayCount(ru.getId());
+	}
 
 	@Transactional
 	public Question saveQuestion(@Valid Question question) throws DataAccessException {
@@ -58,7 +75,13 @@ public class QuestionService {
 		RegularUser ru = regularUserRepository.findByEmail(email)
 				.orElseThrow(() -> new AccessDeniedException("Only regular users can create questions"));
 		boolean isPremium = Boolean.TRUE.equals(ru.getPremiumActive());
-
+		if (!isPremium) {
+			long userQuestionCount = questionRepository.countByCreatorId(ru.getId());
+			long todayQuestionCount = questionsTodayCount(ru.getId());
+			if (todayQuestionCount >= 3) {
+				throw new UpperPlanFeatureException("Free plan users can only create up to 3 questions.");
+			}
+		}
 		question.setCreator(ru);
 		question.setRadiusKm(resolveRadiusKm(question.getRadiusKm(), isPremium));
 		applyDefaults(question, isPremium);

--- a/src/main/java/com/streetask/app/question/QuestionService.java
+++ b/src/main/java/com/streetask/app/question/QuestionService.java
@@ -51,8 +51,10 @@ public class QuestionService {
 		this.eventPublisher = eventPublisher;
 	}
 	public long questionsTodayCount(UUID creatorId) {
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+		LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
 		return StreamSupport.stream(questionRepository.findByCreatorId(creatorId).spliterator(), false)
-				.filter(q -> q.getCreatedAt().isAfter(LocalDateTime.now(ZoneId.of("UTC")).minusHours(24)))
+				.filter(q -> q.getCreatedAt().isAfter(startOfDay))
 				.count();
 	}
 

--- a/src/test/java/com/streetask/app/question/QuestionServiceTest.java
+++ b/src/test/java/com/streetask/app/question/QuestionServiceTest.java
@@ -623,4 +623,182 @@ class QuestionServiceTest {
 		verify(questionRepository, never()).saveAll(any());
 	}
 
+	// =============== DAILY LIMIT TESTS ===============
+
+	@Test
+	void questionsTodayCount_shouldCountOnlyQuestionsFromSameDayCalendar() {
+		// Arrange
+		UUID userId = testCreator.getId();
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+		LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
+		
+		Question question1 = new Question();
+		question1.setCreatedAt(now.minusHours(2)); // 2 hours ago, same day - counts
+		
+		Question question2 = new Question();
+		question2.setCreatedAt(startOfDay.plusMinutes(1)); // Just after midnight, same day - counts
+		
+		Question question3 = new Question();
+		question3.setCreatedAt(startOfDay.minusSeconds(1)); // Just before midnight, previous day - doesn't count
+		
+		when(questionRepository.findByCreatorId(userId))
+				.thenReturn(Arrays.asList(question1, question2, question3));
+
+		// Act
+		long count = questionService.questionsTodayCount(userId);
+
+		// Assert
+		assertThat(count).isEqualTo(2);
+		verify(questionRepository, times(1)).findByCreatorId(userId);
+	}
+
+	@Test
+	void questionsTodayCount_shouldReturnZeroWhenNoQuestionsCreated() {
+		// Arrange
+		UUID userId = testCreator.getId();
+		when(questionRepository.findByCreatorId(userId)).thenReturn(Arrays.asList());
+
+		// Act
+		long count = questionService.questionsTodayCount(userId);
+
+		// Assert
+		assertThat(count).isZero();
+		verify(questionRepository, times(1)).findByCreatorId(userId);
+	}
+
+	@Test
+	void getTodayQuestionCountForAuthenticatedUser_shouldReturnCountForAuthenticatedUser() {
+		// Arrange
+		UUID userId = testCreator.getId();
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+		
+		Question question1 = new Question();
+		question1.setCreatedAt(now.minusHours(1));
+		
+		Question question2 = new Question();
+		question2.setCreatedAt(now.minusHours(5));
+		
+		when(questionRepository.findByCreatorId(userId))
+				.thenReturn(Arrays.asList(question1, question2));
+
+		// Act
+		long count = questionService.getTodayQuestionCountForAuthenticatedUser();
+
+		// Assert
+		assertThat(count).isEqualTo(2);
+		verify(regularUserRepository, times(1)).findByEmail(TEST_EMAIL);
+		verify(questionRepository, times(1)).findByCreatorId(userId);
+	}
+
+	@Test
+	void getTodayQuestionCountForAuthenticatedUser_shouldThrowExceptionWhenUserNotFound() {
+		// Arrange
+		when(regularUserRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
+
+		// Act & Assert
+		assertThatThrownBy(() -> questionService.getTodayQuestionCountForAuthenticatedUser())
+				.isInstanceOf(AccessDeniedException.class)
+				.hasMessageContaining("Only regular users can check their question count");
+	}
+
+	@Test
+	void saveQuestion_shouldRejectFreeUserAfter3QuestionsPerDay() {
+		// Arrange
+		testCreator.setPremiumActive(false);
+		UUID userId = testCreator.getId();
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+		
+		// Mock 3 existing questions created today
+		Question question1 = new Question();
+		question1.setCreatedAt(now.minusHours(1));
+		
+		Question question2 = new Question();
+		question2.setCreatedAt(now.minusHours(4));
+		
+		Question question3 = new Question();
+		question3.setCreatedAt(now.minusHours(8));
+		
+		when(questionRepository.findByCreatorId(userId))
+				.thenReturn(Arrays.asList(question1, question2, question3));
+
+		Question newQuestion = new Question();
+		newQuestion.setTitle("Fourth Question");
+		newQuestion.setContent("This should fail");
+
+		// Act & Assert
+		assertThatThrownBy(() -> questionService.saveQuestion(newQuestion))
+				.isInstanceOf(UpperPlanFeatureException.class)
+				.hasMessageContaining("Free plan users can only create up to 3 questions");
+		
+		verify(questionRepository, never()).save(any(Question.class));
+		verify(eventPublisher, never()).publishEvent(any());
+	}
+
+	@Test
+	void saveQuestion_shouldAllowFreeUserToCreateUpTo3QuestionsPerDay() {
+		// Arrange
+		testCreator.setPremiumActive(false);
+		UUID userId = testCreator.getId();
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+		
+		// Mock 2 existing questions created today
+		Question question1 = new Question();
+		question1.setCreatedAt(now.minusHours(2));
+		
+		Question question2 = new Question();
+		question2.setCreatedAt(now.minusHours(6));
+		
+		when(questionRepository.findByCreatorId(userId))
+				.thenReturn(Arrays.asList(question1, question2));
+
+		Question newQuestion = new Question();
+		newQuestion.setTitle("Third Question");
+		newQuestion.setContent("This should succeed");
+		newQuestion.setRadiusKm(0.5f);
+
+		when(questionRepository.save(any(Question.class))).thenReturn(newQuestion);
+
+		// Act
+		Question saved = questionService.saveQuestion(newQuestion);
+
+		// Assert
+		assertThat(saved).isNotNull();
+		verify(questionRepository, times(1)).save(newQuestion);
+		verify(eventPublisher, times(1)).publishEvent(any(QuestionCreatedEvent.class));
+	}
+
+	@Test
+	void saveQuestion_shouldNotEnforceDailyLimitForPremiumUsers() {
+		// Arrange
+		testCreator.setPremiumActive(true);
+		UUID userId = testCreator.getId();
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+		
+		// Mock 5 existing questions created today (way over the free limit)
+		// Note: This mock is not used for premium users since daily limit is not enforced
+		Question[] questions = new Question[5];
+		for (int i = 0; i < 5; i++) {
+			questions[i] = new Question();
+			questions[i].setCreatedAt(now.minusHours(i + 1));
+		}
+		
+		lenient().when(questionRepository.findByCreatorId(userId))
+				.thenReturn(Arrays.asList(questions));
+
+		Question newQuestion = new Question();
+		newQuestion.setTitle("Sixth Premium Question");
+		newQuestion.setContent("Premium users have no daily limit");
+		newQuestion.setRadiusKm(0.2f);
+
+		when(questionRepository.save(any(Question.class))).thenReturn(newQuestion);
+
+		// Act
+		Question saved = questionService.saveQuestion(newQuestion);
+
+		// Assert
+		assertThat(saved).isNotNull();
+		verify(questionRepository, times(1)).save(newQuestion);
+		verify(eventPublisher, times(1)).publishEvent(any(QuestionCreatedEvent.class));
+	}
+
 }


### PR DESCRIPTION
Implemented a 3-question-per-day limit for free plan users. Premium users remain unlimited.

Backend: Added question count tracking methods and GET endpoint to retrieve daily count. Enforces limit on question creation.

Frontend: Displays red alert when limit is reached with option to visit shop. Post button is disabled when limit exceeded.
!!Shop button is implemented but do anything, since the shop screen isnt implemented yet

Tests: 7 new unit tests covering count logic, calendar boundaries, and limit enforcement. All 420+ tests passing.