### PR TITLE
docs: add communication improvement plan and delivery thresholds

### DIFF
--- a/docs/Sprint 3/CLOCKIFY_POLICY.md
+++ b/docs/Sprint 3/CLOCKIFY_POLICY.md
@@ -1,38 +1,38 @@
-# Política de Uso de Clockify y Umbral de Cumplimiento (ISPP-G10)
+# Clockify Usage Policy and Compliance Threshold (ISPP-G10)
 
-Este documento establece las normas obligatorias para el registro de tiempos del equipo **StreetAsk**, garantizando que el esfuerzo dedicado por los 20 miembros sea transparente y auditable para las entregas y para los profesores.
+This document establishes the mandatory rules for time tracking for the **StreetAsk** team, ensuring that the effort contributed by the 20 members is transparent and auditable for deliverables and for the professors.
 
-## 1. Compromiso de Horas y Registro
-* **Compromiso Semanal:** Cada miembro del equipo tiene el compromiso obligatorio de registrar **10 horas semanales**.
-* **Identificación de Tareas:** Todos los registros deben incluir el ID de la Issue de GitHub correspondiente y una descripción breve pero clara de la actividad (ej: *#521 - Redacción de política de Clockify*).
-* **Naturaleza del Trabajo:** Se deben registrar todas las actividades: desarrollo de código, redacción de documentación, reuniones de subgrupo, la reunión general de los sábados en Teams y la preparación de presentaciones.
+## 1. Hour Commitment and Tracking
+* **Weekly Commitment:** Each team member is required to log **10 hours per week**.
+* **Task Identification:** All entries must include the corresponding GitHub Issue ID and a brief but clear description of the activity (e.g., *#521 - Writing Clockify policy*).
+* **Nature of Work:** All activities must be logged: code development, documentation writing, subgroup meetings, the Saturday general Teams meeting, and presentation preparation.
 
-## 2. Cierre Semanal y Plazos (Deadlines)
-El ciclo de registro es fundamental para la generación de métricas de equipo:
-* **Cierre de Horas:** El límite improrrogable para volcar las horas en el sistema es el **Miércoles a las 21:00h**.
-* **Consolidación de Datos:** * En semanas de **Presentación Evaluable**, los datos se extraen el miércoles después de las 21:00h o el jueves por la mañana para su entrega a los profesores.
-    * En semanas no evaluables, los datos se registran igualmente para mantener las métricas de rendimiento interno del equipo.
+## 2. Weekly Closure and Deadlines
+The tracking cycle is essential for generating team metrics:
+* **Hours Closure:** The non-extendable deadline to enter hours into the system is **Wednesday at 21:00**.
+* **Data Consolidation:** In weeks with a **graded presentation**, data is extracted Wednesday after 21:00 or Thursday morning for submission to the professors.
+    * In non-graded weeks, the data is still recorded to maintain the team’s internal performance metrics.
 
-## 3. Protocolo de Transparencia y Notificación
-Para asegurar que nadie se quede fuera de las actas por descuido:
-* **Penalización por Transparencia:** Antes de cerrar las actas definitivas en Clockify, se realizará una revisión del estado de los registros.
-* **Aviso Obligatorio:** Si se detecta que algún miembro no ha completado sus horas antes del cierre, **se le debe notificar directamente** para que pueda regularizar su situación de inmediato. 
-* **Umbral de Cumplimiento:** Una tarea no se considerará "Finalizada" si el esfuerzo dedicado no está reflejado fielmente en la plataforma antes del cierre semanal.
+## 3. Transparency and Notification Protocol
+To ensure no one is left out of the records by oversight:
+* **Transparency Review:** Before finalizing records in Clockify, the status of entries will be reviewed.
+* **Mandatory Notice:** If any member is found to have not completed their hours before the closure, **they must be notified directly** so they can regularize their record immediately.
+* **Compliance Threshold:** A task will not be considered "Completed" if the effort spent is not faithfully reflected in the platform before the weekly closure.
 
-## 4. Responsabilidades
-* **Gestión de Documentación:** Siguiendo nuestra política de equipo, cualquier miembro al que se le asigne la Issue de documentación puede actualizar este protocolo en el repositorio.
-* **Responsabilidad Individual:** Cada miembro es responsable de su propio registro. Es vital cumplir el horario para no distorsionar las métricas de esfuerzo del subgrupo (S, Z, J, G4).
-* **Soporte:** Si surgen problemas técnicos con Clockify, el miembro afectado debe comunicarlo en su subgrupo de WhatsApp antes del miércoles a las 21:00h.
-
----
-
-## 5. Qué se debe registrar (Categorías)
-No solo se registra el código. También es obligatorio registrar:
-* Reuniones (Teams de los sábados, reuniones de subgrupo).
-* Documentación y diseño.
-* Revisiones de Pull Requests (Code Review).
-* Preparación de la presentación (especialmente para el G4).
+## 4. Responsibilities
+* **Documentation Management:** Following our team policy, any member assigned the documentation Issue may update this protocol in the repository.
+* **Individual Responsibility:** Each member is responsible for their own time tracking. It is vital to comply with the schedule so as not to distort subgroup effort metrics (S, Z, J, G4).
+* **Support:** If technical issues arise with Clockify, the affected member must report it in their subgroup WhatsApp before Wednesday at 21:00.
 
 ---
 
-**Nota:** La métrica de Clockify es el reflejo oficial de nuestro trabajo hacia los profesores. El cumplimiento estricto de las 10 horas semanales garantiza que la carga de trabajo sea equilibrada y visible para todos. El incumplimiento sistemático de esta política afecta a la nota colectiva y a la visibilidad del proyecto ante los tutores. Si tienes problemas técnicos con la herramienta, contacta con tu SM de subgrupo de inmediato.
+## 5. What Should Be Logged (Categories)
+Not only code must be tracked. It is also mandatory to log:
+* Meetings (Saturday Teams, subgroup meetings).
+* Documentation and design.
+* Pull Request reviews (Code Review).
+* Presentation preparation (especially for G4).
+
+---
+
+**Note:** The Clockify metric is the official reflection of our work for the professors. Strict compliance with the 10-hour weekly commitment ensures the workload is balanced and visible to everyone. Systematic noncompliance with this policy affects the collective grade and the project’s visibility to tutors. If you have technical problems with the tool, contact your subgroup SM immediately.

--- a/docs/Sprint 3/INCIDENT_PROTOCOL.md
+++ b/docs/Sprint 3/INCIDENT_PROTOCOL.md
@@ -66,3 +66,27 @@ El éxito de la presentación depende de la estabilidad del Miércoles:
 * **Supervisión:** Monitorizar que nadie esté bloqueado más de 4 horas sin recibir respuesta.
 * **Mediación:** Resolver conflictos de merge complejos que el subgrupo no pueda manejar.
 * **Control de Calidad:** Asegurar que los comentarios en las Issues bloqueadas sean claros para su revisión en la reunión post-clase.
+
+## 8. Plan de Mejora de Fluidez y Eficacia de la Comunicación
+
+En respuesta al feedback de los grupos de interés, este plan busca garantizar que la información fluya sin interrupciones y que existan métricas claras para evaluar nuestra coordinación.
+
+### 8.1. Estrategias de Mejora de Fluidez
+* **Sincronización Inter-Grupos:** Los **4 Scrum Masters** realizarán un resumen de los avances de sus respectivos subgrupos en el **Grupo General** cada martes a las 20:00. Esto garantiza una visión global antes del cierre del miércoles.
+* **Compromiso de Disponibilidad y Entrega:** Una vez asignadas las Issues el **Sábado a mediodía**, cada miembro debe comunicar en su subgrupo de WhatsApp el plazo estimado en el que prevé terminar su tarea. Esto permite detectar cuellos de botella desde el inicio del ciclo.
+* **Registro de Decisiones en GitHub:** Cualquier decisión técnica tomada por WhatsApp que afecte al desarrollo debe quedar reflejada como comentario en la Issue correspondiente. La "verdad oficial" del proyecto reside en GitHub.
+
+### 8.2. Umbrales de Medición de Efectividad (KPIs)
+Para medir si la comunicación es eficaz, evaluaremos semanalmente los siguientes indicadores:
+
+| Indicador (Métrica) | Umbral de Éxito | Método de Medición |
+| :--- | :--- | :--- |
+| **Compromiso de Entrega** | 100% de los miembros | El sábado tras la reunión, todos deben haber dado una fecha estimada en su subgrupo. |
+| **Consistencia GitHub/Clockify** | 100% | Todas las horas de Clockify deben coincidir con una Issue activa y con descripción clara. |
+| **Resolución de Bloqueos** | < 24 horas | Tiempo desde que una Issue se marca como "Blocked" hasta que se registra una solución o avance. |
+| **Alineación de Presentación** | 0 incidencias críticas | El Grupo 4 confirma los jueves que no ha habido falta de información para la demo. |
+
+### 8.3. Acciones Correctoras
+Si los umbrales de éxito bajan del 80% en cualquiera de los puntos anteriores (salvo los de cumplimiento 100% obligatorio):
+1. Los Scrum Masters analizarán si el problema es de un subgrupo o una falta de herramientas.
+2. Se realizará una "Retrospectiva de Emergencia" el sábado para ajustar el flujo y evitar que el problema se repita en el siguiente ciclo.

--- a/docs/Sprint 3/INCIDENT_PROTOCOL.md
+++ b/docs/Sprint 3/INCIDENT_PROTOCOL.md
@@ -1,92 +1,93 @@
-# Protocolo de Comunicación y Gestión de Incidencias (ISPP-G10)
+# Communication and Incident Management Protocol (ISPP-G10)
 
-Este documento define el protocolo oficial para la gestión de bloqueos, comunicación interna y el ciclo de entregas del proyecto **StreetAsk**. El objetivo es garantizar que el ritmo de desarrollo no se detenga y que el **Grupo 4** disponga de material estable para las presentaciones de los jueves.
+This document defines the official protocol for managing blockers, internal communication, and the project delivery cycle for **StreetAsk**. The goal is to ensure that development momentum does not stop and that **Group 4** has stable material for Thursday presentations.
 
-## 1. Ciclo Semanal de Trabajo ("Ciclo StreetAsk")
-Nuestra semana de desarrollo se estructura de jueves a miércoles para alinearnos con el feedback de clase y las entregas:
+## 1. Weekly Work Cycle ("StreetAsk Cycle")
+Our development week is structured from Thursday to Wednesday to align with class feedback and deliverables:
 
-* **Jueves (19:30+):** Tras la clase, los **4 Scrum Masters (SM)** se reúnen para analizar el feedback recibido en la presentación y planificar la estrategia de la siguiente semana.
-* **Viernes:** Los SM crean las Issues en GitHub y organizan el tablero Kanban basándose en los nuevos requisitos y el feedback del jueves.
-* **Sábado (Mañana):** Reunión general por **Teams**. Se asignan las tareas y el desarrollo comienza oficialmente justo después de la llamada.
-* **Sábado (Tarde) - Domingo - Lunes - Martes:** Fase de desarrollo intensivo y resolución de dudas técnicas.
-* **Miércoles (18:00): DEADLINE INTERNO.** Todas las tareas deben estar en Pull Request (PR) o mergeadas a `Trunk`.
-* **Miércoles (Noche) y Jueves (Mañana):** El **Grupo de Presentación (G4)** consolida el material y prepara la presentación.
-* **Jueves (15:30):** Entrega y Presentación en clase.
+* **Thursday (19:30+):** After class, the **4 Scrum Masters (SM)** meet to review the feedback received during the presentation and plan the strategy for the following week.
+* **Friday:** The SMs create Issues in GitHub and organize the Kanban board based on the new requirements and Thursday feedback.
+* **Saturday (Morning):** General meeting on **Teams**. Tasks are assigned and development officially begins right after the call.
+* **Saturday (Afternoon) - Sunday - Monday - Tuesday:** Intensive development phase and technical issue resolution.
+* **Wednesday (18:00): INTERNAL DEADLINE.** All tasks must be in Pull Request (PR) or merged into `Trunk`.
+* **Wednesday (Night) and Thursday (Morning):** The **Presentation Group (G4)** consolidates the material and prepares the presentation.
+* **Thursday (15:30):** Delivery and presentation in class.
 
 ---
 
-## 2. Estructura de Canales (Comunidad WhatsApp)
-Para minimizar el ruido en un equipo de 20 personas, se establece la siguiente jerarquía:
+## 2. Channel Structure (WhatsApp Community)
+To minimize noise in a 20-person team, the following hierarchy is established:
 
-| Canal | Audiencia | Propósito |
+| Channel | Audience | Purpose |
 | :--- | :--- | :--- |
-| **Subgrupos (S, Z, J, G4)** | Miembros + 4 SM | **Primera línea de defensa.** Consultas técnicas y bloqueos de tareas del grupo. |
-| **Grupo General** | Todo el equipo | Avisos de impacto global (ej: servidor caído, errores críticos en `Trunk`). |
-| **Grupo Avisos** | Todo el equipo | **Solo lectura.** Comunicaciones oficiales y urgentes de los SM. |
-| **Administración** | Solo 4 SM | Coordinación de gestión, reasignación de tareas y decisiones estratégicas. |
-
----
-## 3. Roles y Colaboración Total
-Aunque el equipo se divide en subgrupos (S, Z, J, G4), seguimos una filosofía de **"todos hacen de todo"**:
-* **Multidisciplinar:** Los miembros del grupo de presentación (G4) también programan y tocan código.
-* **Apoyo Cruzado:** Cualquier miembro de un subgrupo puede (y debe) echar una mano a otros grupos si están bloqueados o si la carga de trabajo lo requiere, especialmente cuando se acerca el deadline del miércoles.
+| **Subgroups (S, Z, J, G4)** | Members + 4 SM | **First line of defense.** Technical questions and task blockers of the group. |
+| **General Group** | Entire team | Notices with global impact (e.g., server down, critical errors in `Trunk`). |
+| **Announcements Group** | Entire team | **Read-only.** Official and urgent communications from the SMs. |
+| **Administration** | Only 4 SM | Management coordination, task reassignment, and strategic decisions. |
 
 ---
 
-## 4. Gestión de Bloqueos (Escalada de Incidencias)
-Si un desarrollador no puede avanzar en su tarea (Bloqueo/Blocker), debe seguir estos tiempos:
-
-1.  **Auto-resolución (30 min):** Investigación en logs, documentación o StackOverflow.
-2.  **Consulta al Subgrupo (1-3 horas):** Preguntar por el WhatsApp del subequipo. Compañeros y SM asignados intentarán ayudar.
-3.  **Escalada a SM (+3 horas):** Si no hay solución, mencionar directamente a los Scrum Masters en el subgrupo.
-4.  **Registro en GitHub:** Mover la Issue a la columna **"Blocked"** y añadir un comentario detallando el error técnico. Esto es vital para la revisión de los jueves.
+## 3. Roles and Full Collaboration
+Although the team is divided into subgroups (S, Z, J, G4), we follow a philosophy of **"everyone does everything"**:
+* **Multidisciplinary:** Members of the presentation group (G4) also code and contribute technically.
+* **Cross Support:** Any member of a subgroup can (and should) help other groups if they are blocked or if the workload requires it, especially as the Wednesday deadline approaches.
 
 ---
 
-## 5. Flujo de Trabajo y Pull Requests (PR)
-Para mantener la integridad del código:
+## 4. Blocker Management (Incident Escalation)
+If a developer cannot advance on their task (Blocker), they must follow these timeframes:
 
-* **Regla de Oro:** Prohibido trabajar directamente sobre `Trunk`. Siempre rama por Issue (`feature/ID-desc`).
-* **Sincronización:** Antes de reportar un error o subir una PR, es obligatorio hacer `git pull trunk` para resolver conflictos en local.
-* **Revisión de PR:** Los revisores/SM deben dar feedback en un máximo de **24 horas** para evitar cuellos de botella antes del miércoles.
-* **Merge:** El flujo es `Branch` ➡️ `Trunk`. El paso a `Main` se realiza cada 2 semanas previo al Sprint.
-
----
-
-## 6. Compromiso con la Presentación (Grupo 4)
-El éxito de la presentación depende de la estabilidad del Miércoles:
-
-* **Disponibilidad:** El miércoles tarde/noche, los responsables de tareas deben estar atentos al WhatsApp para resolver dudas del Grupo 4 sobre el funcionamiento de las features.
-* **Hotfixes:** Si el Grupo 4 detecta un bug crítico durante la preparación de la presentación, se comunicará de forma **urgente** al subgrupo responsable para un fix inmediato.
-* **Transparencia:** Si una Issue no va a estar lista el miércoles a las 18:00, el responsable debe avisar con antelación a su subgrupo para que el Grupo 4 ajuste el contenido de la presentación.
+1. **Self-resolution (30 min):** Investigate logs, documentation, or StackOverflow.
+2. **Subgroup consultation (1-3 hours):** Ask in the subgroup WhatsApp. Teammates and assigned SMs will try to help.
+3. **Escalation to SM (+3 hours):** If there is no solution, mention the Scrum Masters directly in the subgroup.
+4. **Record on GitHub:** Move the Issue to the **"Blocked"** column and add a detailed comment describing the technical issue. This is vital for Thursday review.
 
 ---
 
-## 7. Responsabilidades de los Scrum Masters
-* **Supervisión:** Monitorizar que nadie esté bloqueado más de 4 horas sin recibir respuesta.
-* **Mediación:** Resolver conflictos de merge complejos que el subgrupo no pueda manejar.
-* **Control de Calidad:** Asegurar que los comentarios en las Issues bloqueadas sean claros para su revisión en la reunión post-clase.
+## 5. Workflow and Pull Requests (PR)
+To maintain code integrity:
 
-## 8. Plan de Mejora de Fluidez y Eficacia de la Comunicación
+* **Golden rule:** Do not work directly on `Trunk`. Always branch for each Issue (`feature/ID-desc`).
+* **Sync:** Before reporting a bug or opening a PR, it is mandatory to run `git pull trunk` and resolve conflicts locally.
+* **PR review:** Reviewers/SMs must provide feedback within **24 hours** to avoid bottlenecks before Wednesday.
+* **Merge:** The flow is `Branch` ➡️ `Trunk`. Promotion to `Main` occurs every 2 weeks before the Sprint.
 
-En respuesta al feedback de los grupos de interés, este plan busca garantizar que la información fluya sin interrupciones y que existan métricas claras para evaluar nuestra coordinación.
+---
 
-### 8.1. Estrategias de Mejora de Fluidez
-* **Sincronización Inter-Grupos:** Los **4 Scrum Masters** realizarán un resumen de los avances de sus respectivos subgrupos en el **Grupo General** cada martes a las 20:00. Esto garantiza una visión global antes del cierre del miércoles.
-* **Compromiso de Disponibilidad y Entrega:** Una vez asignadas las Issues el **Sábado a mediodía**, cada miembro debe comunicar en su subgrupo de WhatsApp el plazo estimado en el que prevé terminar su tarea. Esto permite detectar cuellos de botella desde el inicio del ciclo.
-* **Registro de Decisiones en GitHub:** Cualquier decisión técnica tomada por WhatsApp que afecte al desarrollo debe quedar reflejada como comentario en la Issue correspondiente. La "verdad oficial" del proyecto reside en GitHub.
+## 6. Commitment to the Presentation (Group 4)
+The success of the presentation depends on Wednesday’s stability:
 
-### 8.2. Umbrales de Medición de Efectividad (KPIs)
-Para medir si la comunicación es eficaz, evaluaremos semanalmente los siguientes indicadores:
+* **Availability:** On Wednesday afternoon/evening, task owners must stay alert on WhatsApp to resolve Group 4 questions about feature behavior.
+* **Hotfixes:** If Group 4 detects a critical bug while preparing the presentation, they must urgently notify the responsible subgroup for an immediate fix.
+* **Transparency:** If an Issue will not be ready by Wednesday at 18:00, the owner must warn their subgroup in advance so Group 4 can adjust the presentation content.
 
-| Indicador (Métrica) | Umbral de Éxito | Método de Medición |
+---
+
+## 7. Responsibilities of the Scrum Masters
+* **Monitoring:** Ensure no one remains blocked for more than 4 hours without receiving a response.
+* **Mediation:** Resolve complex merge conflicts that the subgroup cannot handle.
+* **Quality Control:** Ensure comments on blocked Issues are clear for review in the post-class meeting.
+
+## 8. Plan to Improve Communication Flow and Effectiveness
+
+In response to stakeholder feedback, this plan aims to ensure information flows without interruption and that there are clear metrics to evaluate our coordination.
+
+### 8.1. Strategies to Improve Flow
+* **Inter-group synchronization:** The **4 Scrum Masters** will post a summary of the progress of their respective subgroups in the **General Group** every Tuesday at 20:00. This ensures a global view before Wednesday’s closure.
+* **Commitment to availability and delivery:** Once Issues are assigned on **Saturday at noon**, each member must communicate in their subgroup WhatsApp the estimated deadline for completing their task. This allows bottlenecks to be detected from the start of the cycle.
+* **Record decisions on GitHub:** Any technical decision made on WhatsApp that affects development must be recorded as a comment on the corresponding Issue. The project’s official source of truth is GitHub.
+
+### 8.2. Effectiveness Measurement Thresholds (KPIs)
+To measure whether communication is effective, we will evaluate the following indicators weekly:
+
+| Indicator (Metric) | Success Threshold | Measurement Method |
 | :--- | :--- | :--- |
-| **Compromiso de Entrega** | 100% de los miembros | El sábado tras la reunión, todos deben haber dado una fecha estimada en su subgrupo. |
-| **Consistencia GitHub/Clockify** | 100% | Todas las horas de Clockify deben coincidir con una Issue activa y con descripción clara. |
-| **Resolución de Bloqueos** | < 24 horas | Tiempo desde que una Issue se marca como "Blocked" hasta que se registra una solución o avance. |
-| **Alineación de Presentación** | 0 incidencias críticas | El Grupo 4 confirma los jueves que no ha habido falta de información para la demo. |
+| **Delivery Commitment** | 100% of members | After the Saturday meeting, everyone must have provided an estimated completion date in their subgroup. |
+| **GitHub/Clockify Consistency** | 100% | All Clockify hours must match an active Issue with a clear description. |
+| **Blocker Resolution** | < 24 hours | Time from when an Issue is marked "Blocked" until a solution or progress is recorded. |
+| **Presentation Alignment** | 0 critical incidents | Group 4 confirms on Thursdays that there was no missing information for the demo. |
 
-### 8.3. Acciones Correctoras
-Si los umbrales de éxito bajan del 80% en cualquiera de los puntos anteriores (salvo los de cumplimiento 100% obligatorio):
-1. Los Scrum Masters analizarán si el problema es de un subgrupo o una falta de herramientas.
-2. Se realizará una "Retrospectiva de Emergencia" el sábado para ajustar el flujo y evitar que el problema se repita en el siguiente ciclo.
+### 8.3. Corrective Actions
+If success thresholds fall below 80% in any of the above points (except those with mandatory 100% compliance):
+1. The Scrum Masters will analyze whether the problem is subgroup-related or caused by a lack of tools.
+2. An "Emergency Retrospective" will be held on Saturday to adjust the flow and prevent the issue from repeating in the next cycle.


### PR DESCRIPTION
Actualizar el plan de comunicación según el feedback de los grupos de interés para mejorar la fluidez y establecer métricas de cumplimiento.

## Cambios realizados
- **Sincronización:** Resúmenes semanales de los SM en el Grupo General (martes).
- **Compromiso:** Obligación de estimar fecha de entrega los sábados tras la asignación.
- **Trazabilidad:** Registro obligatorio de decisiones de WhatsApp en los comentarios de GitHub.
- **Métricas (KPIs):** Definición de umbrales para medir la efectividad (Compromiso 100%, Resolución de bloqueos <24h, Consistencia Clockify/GitHub).
