### PR TITLE
docs: update estimation costs

### DIFF
--- a/docs/Sprint 1/estimation_costs.md
+++ b/docs/Sprint 1/estimation_costs.md
@@ -1,46 +1,44 @@
 # Time and Cost Estimation Report — ISPP-G8 StreetAsk
 
 **Date:** 02/03/2026 | **Project:** ISPP-G8 | **Duration:** 11 weeks  
-**Team:** 20 people (16 Dev @€12.50/h + 4 PM @€14.80/h)
+**Team:** 20 people (16 Dev @€23.85/h + 4 PM @€39.48/h)
 
 ---
 
-## � HOURLY RATE METHODOLOGY
+## HOURLY RATE METHODOLOGY
 
 **Rates applied:**
-- **Developers:** €12.50/h (full TCE included)
-- **Project Managers:** €14.80/h (full TCE included)
+- **Developers:** €23.85/h (full TCE included) (Based on the "Programador/a J2EE / Web - Junior" profile ).
+- **Project Managers:** €39.48/h (full TCE included) (Based on the "Jefe/a de proyecto / Coordinador - Junior" profile ).
 
 **Source & Justification:**
-These rates are based on **junior/academic profile benchmarks** in the Spanish market for university-led software projects (ISPP program context). They include:
-- Gross salary equivalents for entry-level positions (€1,200-€1,500/month)
-- Employer social contributions (~35%)
-- Equipment and indirect costs
+These rates are based on the "Preliminary Market Consultation" for "Professional IT Profiles" published by the Junta de Andalucía (Consejería de Agricultura, Pesca y Desarrollo Rural). They include:
+- Official benchmark: The rates represent the "MEDIA ACOTADA TODOS" (Trimmed Mean), which is the specific reference value CAPDER uses to determine tender amounts for future software contracts.
+- Statistical reliability: This value is calculated like a traditional arithmetic mean but excludes extreme outliers from the data set to ensure market accuracy.
 
 **Market comparison:**
-- Junior developers (Spain, 2026): €10-€15/h (academic/internship context)
-- Mid-level professionals: €20-€35/h
-- Senior consultants: €40-€60/h
+- Junior Development (J2EE/Web): €23.85/h (Trimmed Mean).
+- Junior Project Management: €39.48/h (Trimmed Mean).
+-Other junior benchmarks: Rates in the same category range from €18.57/h for user support to €38.83/h for specialized Business Intelligence consultants
 
-**Reference:** Aligned with ISPP project standards and Spanish labor cost structures for educational/research initiatives.
+**Reference:** Fully aligned with the official market database established by the Servicio de Informática to ensure that tender estimates are within realistic market ranges and serves as a verified baseline for this project
 
 ---
-
-## 💰 PROJECT BUDGET AT A GLANCE
+## PROJECT BUDGET AT A GLANCE
 
 ### Development Costs (Sprint 0 → Sprint 3)
 
 | Phase | Development Cost | Deployment Cost (Azure) | Subtotal |
 |---|---:|---:|---:|
-| **Sprint 0** (Completed) | €5,572.00 | €17.50 | €5,589.50 |
-| **Sprint 1** (Completed) | €5,184.00 | €17.50 | €5,201.50 |
-| **Sprint 2** (Completed) | €7,776.00 | €35.00 | €7,811.00 |
-| **Sprint 3** (Estimated) | €7,776.00 | €52.50 | €7,828.50 |
-| **TOTAL** | **€26,308.00** | **€122.50** | **€26,430.50** |
+| **Sprint 0** (Completed) | €11,726.60 | €17.50 | €11,744.10 |
+| **Sprint 1** (Completed) | €10,910.04 | €17.50 | €10,927.54 |
+| **Sprint 2** (Completed) | €16,365.08 | €35.00 | €16,400.08 |
+| **Sprint 3** (Estimated) | €16,365.08 | €52.50 | €16,417.58 |
+| **TOTAL** | **€55,366.80** | **€122.50** | **€55,489.30** |
 
 ---
 
-## 💻 PHYSICAL INFRASTRUCTURE & SOFTWARE COSTS
+## PHYSICAL INFRASTRUCTURE & SOFTWARE COSTS
 
 ### Hardware (Development Workstations)
 
@@ -62,53 +60,66 @@ These rates are based on **junior/academic profile benchmarks** in the Spanish m
 
 👉 **Total testing devices cost (CAPEX): €1,200**
 
+### Amortization of hardware
+
+This represents the actual cost of equipment usage and depreciation during the 11 weeks of the project duration:
+| Concept  | Value |
+| Total Hardware Value (CAPEX) | €21,200.00 | 
+|Annual Amortization Rate (AEAT - 26%)|€5,512.00 / year|
+|Amortization for 11 weeks (Project charge)|€1,166.00|
+
+According to the updated AEAT 2026 tables, "Equipment for information processing, and computer systems and programs" (Group 5) is subject to a maximum linear coefficient of 26%. This is used to ensure the budget remains realistic for a professional 11-week project lifecycle
+
 ---
 
 ### Software & Collaboration Tools
 
+Calculated for 11 weeks(approx. 2.75 months):
+
 | Tool | Plan | Cost | Justification |
 |---|---|---:|---|
-| GitHub | Free | €0 | Repository, CI/CD, project management |
+| GitHub | Team ($4/user/mo) | €220.00 | Repository, CI/CD, project management |
 | Microsoft Teams | Free | €0 | Communication |
-| Azure | Student credits | Included | Already accounted |
+| Azure | Student credits | ~€258.00 | Est. value of 3 student accounts (~$86 each) |
 | Expo (EAS) | Free tier | €0 | Mobile deployment |
 | OpenStreetMap + Leaflet | Free | €0 | Maps |
 
+**Note:** note that these costs are not actually paid in this specific case—as they are covered by university-provided academic plans—they are intentionally included in this report to simulate a real-world professional project and ensure the budget reflects a standard operational environment.
+
 ## 📋 OPENSTREETMAP & LEAFLET POLICY
 
-✅ **Completely free for monetized apps**
+**Completely free for monetized apps**
 - No licensing fees or revenue commissions
 - No restrictions on premium subscriptions or business models
 - Only requirement: Attribution ("© OpenStreetMap contributors")
 - For massive scale (>1M tile requests/month): Consider self-hosting or Mapbox
 
-👉 **Total software licensing cost: €0**
+👉 **Total software licensing cost: €478.00**
 
 ---
 
-## 📊 TOTAL INFRASTRUCTURE COST
+## TOTAL INFRASTRUCTURE COST
 
 | Category | Cost |
 |---|---:|
 | Azure Infrastructure | €122.50 |
-| Hardware (laptops) | €20,000.00 |
-| Mobile Devices | €1,200.00 |
-| Software Licenses | €0.00 |
-| **TOTAL INFRASTRUCTURE COST** | **€21,322.50** |
+| Hardware amortization | €1,166.00 |
+| Software Licenses | €478.00 |
+| **TOTAL INFRASTRUCTURE COST** | **€1,766.50** |
 
 ---
 
-## 🎯 TOTAL PROJECT COST
+##  TOTAL PROJECT COST
 
 | Category | Cost |
 |---|---:|
-| Labor (Dev + PM) | €26,308.00 |
-| Infrastructure | €21,322.50 |
-| **🎯 TOTAL PROJECT COST** | **€47,630.50** |
+| Labor (Dev + PM) | €55,489.30 |
+| Infrastructure | €1,766.50 |
+| ** TOTAL PROJECT COST** | **€57,255.80** |
 
 ---
 
-## 📚 COST CLASSIFICATION (CAPEX vs OPEX vs TCE)
+## COST CLASSIFICATION (CAPEX vs OPEX vs TCE)
 
 ### CAPEX (Capital Expenditure)
 One-time investments in assets required to start the project:
@@ -122,58 +133,56 @@ One-time investments in assets required to start the project:
 ---
 
 ### OPEX (Operational Expenditure)
-Recurring costs required to operate the project:
+The actual cost required to operate the project during its 11-week lifecycle. This includes labor and the proportional depreciation of assets:
 
-- Team labor → €26,308.00  
-- Future cloud hosting (post-MVP scaling)  
+- Team Labor (Dev + PM) → €55,366.80
+- Hardware Amortization (Depreciation) → €1,166.00
+- Software & Cloud Usage (GitHub + Azure Fees) → €723.00
 
-👉 **Total OPEX (project phase): €26,308.00**
+ **Total OPEX (project phase): €57,255.80**
 
 ---
 
 ### TCE (Total Cost of Employment)
 
-Included in hourly rates:
+These rates are based on the Junta de Andalucía market benchmarks and represent the full cost to the employer, including social security, benefits, and structural costs:
+- Developers (Junior): €23.85/h
+- Project Managers (Junior): €39.48/h
 
-- Gross salary  
-- Employer contributions (~35%)  
-- Indirect costs  
-
-- Developers → €12.50/h  
-- PMs → €14.80/h  
-
+(Includes: Gross salary + Employer social contributions (~35%) + Indirect costs).
 ---
 
 
-## 📊 COST BREAKDOWN
-
+##  COST BREAKDOWN
+To ensure project viability against unforeseen risks, such as technical debt, API changes in Azure, or development delays, a 10% contingency reserve has been applied to the operational base.
 | Role | Hours | Cost | % |
 |---|---:|---:|---:|
-| Developers | 1,560 | €19,500.00 | 40.9% |
-| PMs | 460 | €6,808.00 | 14.3% |
-| Infrastructure (CAPEX) | — | €21,322.50 | 44.8% |
-| **TOTAL** | — | **€47,630.50** | **100%** |
+| Developers | 1,560 | €37,206.00 | 59.1% |
+| PMs | 460 | €18,160.80 | 28.8% |
+| Contingency reserve | - | €5,725.58 | 9.1% |
+| Infrastructure & Deployment (OPEX) | — | €1,889.00 | 3.0% |
+| **TOTAL** | — | **€62.981.38** | **100%** |
 
 ---
 
 ## 🎯 SPRINT SUMMARY
 
 ### Sprint 0 — Foundations [COMPLETED ✅]
-**Dates:** Feb 5–20 (3 weeks) | **Cost:** €5,589.50  
+**Dates:** Feb 5–20 (3 weeks) | **Cost:** €11,744.10
 **Delivered:** Data model, tech stack, CI/CD, business plan, user stories, mockups  
 **Work:** 10 Foundation User Stories + cross-cutting activities
 
 ---
 
 ### Sprint 1 — Core Q&A [COMPLETED ✅]
-**Dates:** Feb 21–Mar 5 (2 weeks) | **Cost:** €5,201.50  
+**Dates:** Feb 21–Mar 5 (2 weeks) | **Cost:** €10,927.54
 **Delivered:** Registration, login, map, geolocated Q&A, answer threads, authentication  
 **Key US:** US-01, US-03, US-08, US-11, US-09, US-13 + infrastructure
 
 ---
 
 ### Sprint 2 — Social Interaction [COMPLETED ✅]
-**Dates:** Mar 6–26 (3 weeks) | **Cost:** €7,811.00  
+**Dates:** Mar 6–26 (3 weeks) | **Cost:** €16,400.08
 **Scope:** User profiles, ratings (like/dislike), push notifications  
 **Key US:** US-06, US-10, US-12, US-04
 
@@ -188,7 +197,7 @@ Included in hourly rates:
 ---
 
 ### Sprint 3 — Events & Business [ESTIMATED]
-**Dates:** Mar 27–Apr 16 (3 weeks) | **Est. Cost:** €7,828.50  
+**Dates:** Mar 27–Apr 16 (3 weeks) | **Est. Cost:** €16,417.58
 **Scope:** Events, business accounts, gamification, admin panel  
 **Key US:** US-15/16/17 (event map), US-28 (business reg), US-29-32 (event CRUD), US-35 (coins), US-37/39 (admin)
 
@@ -217,23 +226,23 @@ Included in hourly rates:
 
 | Users | Monthly Revenue | Break-even |
 |---:|---:|---|
-| 500 | €541.95 | ~88 months |
-| 2,500 | €2,709.75 | ~18 months |
-| **10,000** | **€10,839** | **~4–5 months** ✅ |
-| 50,000 | €54,195 | <1 month |
+| 500 | €541.95 | ~153 months |
+| 2,500 | €2,709.75 | ~30.7 months |
+| **10,000** | **€10,839** | **7.6 months** ✅ |
+| 50,000 | €54,195 | 1.5 month |
 
 ---
 
-**ROI target:** 100% recovery (~€47,630.50) within **4–6 months** at 10k+ MAU is achievable under current monetization assumptions.
+**ROI target:** 100% recovery of the total operational investment (€62,981.38) within ~6 months at 10k+ MAU is achievable under 2026 market conditions.
 
 ## ⚠️ RISKS & CONTINGENCY
 
 | Risk | Likelihood | Buffer |
 |---|---|---:|
-| Development delays | Medium | €3,000 |
-| Infrastructure scaling | Medium | €200/month |
-| Additional hires | Medium | €2,000 |
-| **Total contingency (~10%)** | — | **€4,700** |
+| Development delays | Medium | €3,500 |
+| Infrastructure scaling | Medium | €500 |
+| Additional hires | Medium | €1,725.58 |
+| **Total contingency (~10%)** | — | **€5,725.58** |
 
 ---
 
@@ -242,12 +251,12 @@ Included in hourly rates:
 Two valid cost perspectives exist:
 
 ### Full Investment Scenario (Real Startup)
-- Total cost: **€47,630.50**
-- Includes full infrastructure acquisition (CAPEX)
+- Total cost: **€84,181.38**
+- Includes: Total OPEX (Labor + Amortization + Contingency) + Full Hardware/Asset Acquisition (CAPEX).
 
 ### Operational Scenario (Academic Context)
-- Total cost: **€26,430.50**
-- Assumes pre-existing infrastructure
+- Total cost: **€62,981.38**
+- Includes:Labor, amortized infrastructure usage, software licenses, and risk buffer.
 
 ---
 
@@ -255,7 +264,7 @@ Two valid cost perspectives exist:
 
 | Metric | Value |
 |---|---:|
-| Completed (Sprint 0–2) | €18,602.50 (70.4%) |
-| Remaining (Sprint 3) | €7,828.50 (29.6%) |
+| Completed (Sprint 0–2) | €39,071.72 (70.4%) |
+| Remaining (Sprint 3) | €16,417.58 (29.6%) |
 | Timeline | ~7/11 weeks (~64%) |
 | Status | On track |


### PR DESCRIPTION
🔴🔴🔴¡¡REVISAR MUY BIEN ESTA PR!!🔴🔴🔴

He actualizado las tarifas profesionales (documento de la junta y de PSG1) y el resto de cálculos han cambiado en consecuencia:
- Recálculo de costes de los sprints: Ajuste de los costes de cada fase según los nuevos precios de la Junta de Andalucía (€23.85/h Dev y €39.48/h PM).
- Amortización: Actualización al 26% anual para reflejar el coste operativo real del hardware. (Revisado con la web de hacienda)
- Ajuste del Break-even point