### PR TITLE
feat: move StreetCoins visibility to Balance screen only

### DIFF
--- a/frontend/src/features/profile/BalanceScreen.js
+++ b/frontend/src/features/profile/BalanceScreen.js
@@ -19,6 +19,7 @@ export default function BalanceScreen({ navigation, route }) {
     const [buyModalVisible, setBuyModalVisible] = useState(false);
     const [isStartingCheckoutForPack, setIsStartingCheckoutForPack] = useState('');
     const [purchaseError, setPurchaseError] = useState('');
+    const [showCoinInfo, setShowCoinInfo] = useState(false);
 
     const loadWalletData = useCallback(async () => {
         if (!user?.id) {
@@ -150,7 +151,17 @@ export default function BalanceScreen({ navigation, route }) {
                 <View style={styles.balanceCard}>
                     <Ionicons name="wallet" size={40} color="#FFD700" />
                     <Text style={styles.balanceLabel}>StreetCoins</Text>
-                    <Text style={styles.balanceAmount}>{balance ?? 0}</Text>
+                    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                        <Text style={styles.balanceAmount}>{balance ?? 20}</Text>
+                        <TouchableOpacity
+                            onPress={() => setShowCoinInfo(true)}
+                            style={styles.infoButton}
+                            accessibilityRole="button"
+                            accessibilityLabel="How StreetCoins work"
+                        >
+                            <Text style={styles.infoButtonText}>?</Text>
+                        </TouchableOpacity>
+                    </View>
 
                     <TouchableOpacity
                         style={styles.buyButton}
@@ -250,6 +261,31 @@ export default function BalanceScreen({ navigation, route }) {
                     </Pressable>
                 </Pressable>
             </Modal>
+
+            <Modal
+                visible={showCoinInfo}
+                transparent
+                animationType="fade"
+                onRequestClose={() => setShowCoinInfo(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.modalCard}>
+                        <Text style={styles.modalTitle}>How StreetCoins work</Text>
+
+                        <Text style={styles.modalLine}>+1 coin for each answer you post (minimum 10 characters).</Text>
+                        <Text style={styles.modalLine}>+1 extra if likes are greater than dislikes.</Text>
+                        <Text style={styles.modalLine}>-1 if dislikes are greater than likes.</Text>
+
+                        <Text style={styles.modalNote}>
+                            Coins update automatically when votes change.
+                        </Text>
+
+                        <TouchableOpacity style={styles.modalCloseButton} onPress={() => setShowCoinInfo(false)}>
+                            <Text style={styles.modalCloseText}>Got it</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </Modal>
         </SafeAreaView>
     );
 }
@@ -286,7 +322,17 @@ const styles = StyleSheet.create({
         shadowRadius: 4,
     },
     balanceLabel: { color: '#9ca3af', fontSize: 14, marginTop: 10 },
-    balanceAmount: { color: '#FFD700', fontSize: 48, fontWeight: 'bold', marginTop: 4 },
+    balanceAmount: { color: '#FFD700', fontSize: 48, fontWeight: 'bold', marginTop: 4, marginLeft: 28 },
+    infoButton: {
+        marginLeft: 8,
+        width: 18,
+        height: 18,
+        borderRadius: 9,
+        backgroundColor: '#856404',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    infoButtonText: { color: '#fff', fontSize: 12, fontWeight: '900' },
     buyButton: {
         marginTop: 16,
         flexDirection: 'row',
@@ -350,6 +396,15 @@ const styles = StyleSheet.create({
         marginBottom: 12,
     },
     modalTitle: { fontSize: 16, fontWeight: '800', color: '#1f2937' },
+    modalLine: { fontSize: 14, color: '#343a40', marginBottom: 8, lineHeight: 20 },
+    modalNote: { fontSize: 12, color: '#6c757d', marginTop: 6, marginBottom: 16 },
+    modalCloseButton: {
+        backgroundColor: '#d90429',
+        borderRadius: 12,
+        paddingVertical: 10,
+        alignItems: 'center',
+    },
+    modalCloseText: { color: '#fff', fontSize: 14, fontWeight: '800' },
     modalEmptyState: {
         flexDirection: 'row',
         alignItems: 'center',

--- a/frontend/src/features/profile/ProfileStats.js
+++ b/frontend/src/features/profile/ProfileStats.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, SafeAreaView, ActivityIndicator, Modal } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, SafeAreaView, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../../app/providers/AuthProvider';
@@ -24,7 +24,6 @@ export default function ProfileStats() {
     const [userQuestions, setUserQuestions] = useState([]);
     const [userAnswers, setUserAnswers] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [showCoinInfo, setShowCoinInfo] = useState(false);
 
     useEffect(() => {
         const fetchAllData = async () => {
@@ -123,20 +122,6 @@ export default function ProfileStats() {
                 <View style={styles.headerCard}>
                     <Text style={styles.rangoText}>{serverStats.role}</Text>
                     <Text style={styles.userEmailText}>{user?.email || serverStats.username}</Text>
-                    <View style={styles.coinsRow}>
-                        <View style={styles.coinBadge}>
-                            <Ionicons name="star" size={16} color="#FFD700" />
-                            <Text style={styles.coinsText}>{serverStats.coinBalance} StreetCoins</Text>
-                            <TouchableOpacity
-                                onPress={() => setShowCoinInfo(true)}
-                                style={styles.infoButton}
-                                accessibilityRole="button"
-                                accessibilityLabel="How StreetCoins work"
-                            >
-                                <Text style={styles.infoButtonText}>?</Text>
-                            </TouchableOpacity>
-                        </View>
-                    </View>
                 </View>
 
                 <View style={styles.statsGrid}>
@@ -203,31 +188,6 @@ export default function ProfileStats() {
                 </View>
                 <View style={{ height: 40 }} />
             </ScrollView>
-
-            <Modal
-                visible={showCoinInfo}
-                transparent
-                animationType="fade"
-                onRequestClose={() => setShowCoinInfo(false)}
-            >
-                <View style={styles.modalOverlay}>
-                    <View style={styles.modalCard}>
-                        <Text style={styles.modalTitle}>How StreetCoins work</Text>
-
-                        <Text style={styles.modalLine}>+1 coin for each answer you post (minimum 10 characters).</Text>
-                        <Text style={styles.modalLine}>+1 extra if likes are greater than dislikes.</Text>
-                        <Text style={styles.modalLine}>-1 if dislikes are greater than likes.</Text>
-
-                        <Text style={styles.modalNote}>
-                            Coins update automatically when votes change.
-                        </Text>
-
-                        <TouchableOpacity style={styles.modalCloseButton} onPress={() => setShowCoinInfo(false)}>
-                            <Text style={styles.modalCloseText}>Got it</Text>
-                        </TouchableOpacity>
-                    </View>
-                </View>
-            </Modal>
         </SafeAreaView>
     );
 }
@@ -262,19 +222,6 @@ const styles = StyleSheet.create({
     },
     rangoText: { color: '#d90429', fontSize: 24, fontWeight: '900' },
     userEmailText: { color: '#666', fontSize: 14, marginTop: 4, fontWeight: '500' },
-    coinsRow: { marginTop: 15 },
-    coinBadge: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#fff9db', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 20, borderWidth: 1, borderColor: '#ffec99' },
-    coinsText: { color: '#856404', marginLeft: 6, fontSize: 15, fontWeight: '700' },
-    infoButton: {
-        marginLeft: 8,
-        width: 18,
-        height: 18,
-        borderRadius: 9,
-        backgroundColor: '#856404',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-    infoButtonText: { color: '#fff', fontSize: 12, fontWeight: '900' },
     statsGrid: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between', marginBottom: 10 },
     statBox: {
         backgroundColor: '#fff',
@@ -328,28 +275,4 @@ const styles = StyleSheet.create({
     itemFooter: { flexDirection: 'row', alignItems: 'center', marginTop: 6 },
     itemDate: { fontSize: 11, color: '#999', marginLeft: 4, fontWeight: '500' },
     emptyText: { textAlign: 'center', color: '#adb5bd', marginTop: 30, fontStyle: 'italic', fontSize: 14 },
-    modalOverlay: {
-        flex: 1,
-        backgroundColor: 'rgba(0,0,0,0.45)',
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: 24,
-    },
-    modalCard: {
-        width: '100%',
-        maxWidth: 360,
-        backgroundColor: '#fff',
-        borderRadius: 18,
-        padding: 20,
-    },
-    modalTitle: { fontSize: 18, fontWeight: '900', color: '#1a1a1a', marginBottom: 12 },
-    modalLine: { fontSize: 14, color: '#343a40', marginBottom: 8, lineHeight: 20 },
-    modalNote: { fontSize: 12, color: '#6c757d', marginTop: 6, marginBottom: 16 },
-    modalCloseButton: {
-        backgroundColor: '#d90429',
-        borderRadius: 12,
-        paddingVertical: 10,
-        alignItems: 'center',
-    },
-    modalCloseText: { color: '#fff', fontSize: 14, fontWeight: '800' },
 });


### PR DESCRIPTION
- Removed 'coinBadge' and 'coinsRow' from the header card to avoid redundant information.

-  Deleted 'showCoinInfo' modal and its logic, as StreetCoins details now belong exclusively to the Balance screen.

- Deleted Modal import.

- Cleaned up unused styles and state variables related to coins visibility.