### PR TITLE
fix: replace hardcoded localhost URLs with frontend URL variable

### DIFF
--- a/src/main/java/com/streetask/app/business/BusinessSubscriptionService.java
+++ b/src/main/java/com/streetask/app/business/BusinessSubscriptionService.java
@@ -41,10 +41,13 @@ public class BusinessSubscriptionService {
     @Value("${streetask.stripe.subscription-amount-cents:1999}")
     private Integer stripeSubscriptionAmountCents;
 
-    @Value("${streetask.stripe.success-url:http://localhost:8081}")
+    @Value("${FRONTEND_URL:http://localhost:8081}")
+    private String frontendUrl;
+
+    @Value("${streetask.stripe.success-url:${FRONTEND_URL:http://localhost:8081}}")
     private String stripeSuccessUrl;
 
-    @Value("${streetask.stripe.cancel-url:http://localhost:8081}")
+    @Value("${streetask.stripe.cancel-url:${FRONTEND_URL:http://localhost:8081}}")
     private String stripeCancelUrl;
 
     public BusinessSubscriptionService(BusinessAccountRepository businessAccountRepository,
@@ -100,14 +103,16 @@ public class BusinessSubscriptionService {
         String normalizedTaxId = normalizeTaxId(taxId);
 
         if (!hasPendingBasicSignup(normalizedEmail)) {
-            throw new AccessDeniedException("Basic user registration not found. Please complete the basic signup first.");
+            throw new AccessDeniedException(
+                    "Basic user registration not found. Please complete the basic signup first.");
         }
 
         if (businessAccountRepository.existsByTaxId(normalizedTaxId)) {
             throw new AccessDeniedException("Tax ID is already registered.");
         }
 
-        return createPublicStripeCheckoutSessionForSignup(normalizedEmail, normalizedTaxId, companyName, address, website,
+        return createPublicStripeCheckoutSessionForSignup(normalizedEmail, normalizedTaxId, companyName, address,
+                website,
                 description, durationDays);
     }
 
@@ -313,12 +318,15 @@ public class BusinessSubscriptionService {
 
             String metadataEmail = session.getMetadata() == null ? null : session.getMetadata().get("email");
             String metadataTaxId = session.getMetadata() == null ? null : session.getMetadata().get("taxId");
-            String metadataCompanyName = session.getMetadata() == null ? null : session.getMetadata().get("companyName");
+            String metadataCompanyName = session.getMetadata() == null ? null
+                    : session.getMetadata().get("companyName");
             String metadataAddress = session.getMetadata() == null ? null : session.getMetadata().get("address");
             String metadataWebsite = session.getMetadata() == null ? null : session.getMetadata().get("website");
-            String metadataDescription = session.getMetadata() == null ? null : session.getMetadata().get("description");
+            String metadataDescription = session.getMetadata() == null ? null
+                    : session.getMetadata().get("description");
 
-            if (!normalizedEmail.equals(normalizeEmail(metadataEmail)) || !normalizedTaxId.equals(normalizeTaxId(metadataTaxId))) {
+            if (!normalizedEmail.equals(normalizeEmail(metadataEmail))
+                    || !normalizedTaxId.equals(normalizeTaxId(metadataTaxId))) {
                 throw new AccessDeniedException("Stripe session does not belong to this business signup.");
             }
 
@@ -378,7 +386,9 @@ public class BusinessSubscriptionService {
     }
 
     private String appendQuery(String baseUrl, String query) {
-        String safeBaseUrl = StringUtils.hasText(baseUrl) ? baseUrl.trim() : "http://localhost:8081";
+        String safeBaseUrl = StringUtils.hasText(baseUrl)
+                ? baseUrl.trim()
+                : (StringUtils.hasText(frontendUrl) ? frontendUrl.trim() : "http://localhost:8081");
         String separator = safeBaseUrl.contains("?") ? "&" : "?";
         return safeBaseUrl + separator + query;
     }

--- a/src/main/java/com/streetask/app/coins/StreetCoinPurchaseService.java
+++ b/src/main/java/com/streetask/app/coins/StreetCoinPurchaseService.java
@@ -52,10 +52,13 @@ public class StreetCoinPurchaseService {
     @Value("${streetask.stripe.currency:eur}")
     private String stripeCurrency;
 
-    @Value("${streetask.stripe.streetcoins-success-url:http://localhost:8081}")
+    @Value("${FRONTEND_URL:http://localhost:8081}")
+    private String frontendUrl;
+
+    @Value("${streetask.stripe.streetcoins-success-url:${FRONTEND_URL:http://localhost:8081}}")
     private String streetCoinsSuccessUrl;
 
-    @Value("${streetask.stripe.streetcoins-cancel-url:http://localhost:8081}")
+    @Value("${streetask.stripe.streetcoins-cancel-url:${FRONTEND_URL:http://localhost:8081}}")
     private String streetCoinsCancelUrl;
 
     public StreetCoinPurchaseService(UserService userService,
@@ -429,7 +432,9 @@ public class StreetCoinPurchaseService {
     }
 
     private String appendQuery(String baseUrl, String query) {
-        String safeBaseUrl = StringUtils.hasText(baseUrl) ? baseUrl.trim() : "http://localhost:8081";
+        String safeBaseUrl = StringUtils.hasText(baseUrl)
+                ? baseUrl.trim()
+                : (StringUtils.hasText(frontendUrl) ? frontendUrl.trim() : "http://localhost:8081");
         String separator = safeBaseUrl.contains("?") ? "&" : "?";
         return safeBaseUrl + separator + query;
     }

--- a/src/main/java/com/streetask/app/user/UserService.java
+++ b/src/main/java/com/streetask/app/user/UserService.java
@@ -56,10 +56,13 @@ public class UserService {
     @Value("${streetask.stripe.regular-premium-amount-cents:${STRIPE_REGULAR_PREMIUM_AMOUNT_CENTS:999}}")
     private Integer stripeRegularPremiumAmountCents;
 
-    @Value("${streetask.stripe.success-url:http://localhost:8081}")
+    @Value("${FRONTEND_URL:http://localhost:8081}")
+    private String frontendUrl;
+
+    @Value("${streetask.stripe.success-url:${FRONTEND_URL:http://localhost:8081}}")
     private String stripeSuccessUrl;
 
-    @Value("${streetask.stripe.cancel-url:http://localhost:8081}")
+    @Value("${streetask.stripe.cancel-url:${FRONTEND_URL:http://localhost:8081}}")
     private String stripeCancelUrl;
 
     @Autowired
@@ -348,7 +351,9 @@ public class UserService {
     }
 
     private String appendQuery(String baseUrl, String query) {
-        String safeBaseUrl = StringUtils.hasText(baseUrl) ? baseUrl.trim() : "http://localhost:8081";
+        String safeBaseUrl = StringUtils.hasText(baseUrl)
+                ? baseUrl.trim()
+                : (StringUtils.hasText(frontendUrl) ? frontendUrl.trim() : "http://localhost:8081");
         String separator = safeBaseUrl.contains("?") ? "&" : "?";
         return safeBaseUrl + separator + query;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -94,10 +94,10 @@ streetask.stripe.publishable-key=${STRIPE_PUBLISHABLE_KEY:}
 streetask.stripe.currency=${STRIPE_CURRENCY:eur}
 streetask.stripe.subscription-amount-cents=${STRIPE_SUBSCRIPTION_AMOUNT_CENTS:1999}
 streetask.stripe.regular-premium-amount-cents=${STRIPE_REGULAR_PREMIUM_AMOUNT_CENTS:999}
-streetask.stripe.success-url=${STREETASK_STRIPE_SUCCESS_URL:http://localhost:8081}
-streetask.stripe.cancel-url=${STREETASK_STRIPE_CANCEL_URL:http://localhost:8081}
-streetask.stripe.streetcoins-success-url=${STREETASK_STRIPE_STREETCOINS_SUCCESS_URL:http://localhost:8081}
-streetask.stripe.streetcoins-cancel-url=${STREETASK_STRIPE_STREETCOINS_CANCEL_URL:http://localhost:8081}
+streetask.stripe.success-url=${STREETASK_STRIPE_SUCCESS_URL:${STREETASK_WEBSOCKET_ALLOWED_ORIGIN_PATTERNS:http://localhost:8081}}
+streetask.stripe.cancel-url=${STREETASK_STRIPE_CANCEL_URL:${STREETASK_WEBSOCKET_ALLOWED_ORIGIN_PATTERNS:http://localhost:8081}}
+streetask.stripe.streetcoins-success-url=${STREETASK_STRIPE_STREETCOINS_SUCCESS_URL:${STREETASK_WEBSOCKET_ALLOWED_ORIGIN_PATTERNS:http://localhost:8081}}
+streetask.stripe.streetcoins-cancel-url=${STREETASK_STRIPE_STREETCOINS_CANCEL_URL:${STREETASK_WEBSOCKET_ALLOWED_ORIGIN_PATTERNS:http://localhost:8081}}
 
 # Answer reward balancing
 streetask.coins.answer-reward.like-threshold=${STREETASK_ANSWER_REWARD_LIKE_THRESHOLD:3}


### PR DESCRIPTION
This pull request updates the configuration and usage of Stripe-related success and cancel URLs across the codebase to make them more flexible and environment-driven. The changes ensure that the application consistently uses a configurable frontend URL, with improved fallback logic, and updates property resolution in both the Java code and the `application.properties` file.

**Configuration and environment variable improvements:**

* Replaced hardcoded default URLs for Stripe success and cancel URLs with references to a new `FRONTEND_URL` environment variable in `BusinessSubscriptionService`, `StreetCoinPurchaseService`, and `UserService`, allowing for easier configuration across environments. [[1]](diffhunk://#diff-9414dce6422d6c775fbee45078a4540d4ec74060edf2db9aa7d67e17cf64715aL44-R50) [[2]](diffhunk://#diff-4a4371505543126221f67d4b3427667eb644285e4d6d9fc34bcb4a68363b4769L55-R61) [[3]](diffhunk://#diff-0731c4f8a961113b0e6fa0ac8efc5bca74a7a0c7753f8a49ec4fa9d8e0dee416L59-R65)
* Updated the fallback logic in the `appendQuery` method for all affected services to use the new `frontendUrl` property, providing a consistent and centralized way to determine the base URL. [[1]](diffhunk://#diff-9414dce6422d6c775fbee45078a4540d4ec74060edf2db9aa7d67e17cf64715aL381-R391) [[2]](diffhunk://#diff-4a4371505543126221f67d4b3427667eb644285e4d6d9fc34bcb4a68363b4769L432-R437) [[3]](diffhunk://#diff-0731c4f8a961113b0e6fa0ac8efc5bca74a7a0c7753f8a49ec4fa9d8e0dee416L351-R356)
* Modified `application.properties` to use nested environment variable resolution for Stripe URLs, prioritizing specific environment variables and falling back to `STREETASK_WEBSOCKET_ALLOWED_ORIGIN_PATTERNS` or `http://localhost:8081` as defaults.

**Code formatting and readability:**

* Improved line wrapping and formatting for method calls and conditional checks in `BusinessSubscriptionService` to enhance code readability. [[1]](diffhunk://#diff-9414dce6422d6c775fbee45078a4540d4ec74060edf2db9aa7d67e17cf64715aL103-R115) [[2]](diffhunk://#diff-9414dce6422d6c775fbee45078a4540d4ec74060edf2db9aa7d67e17cf64715aL316-R329)