### PR TITLE
fix: count error admin dashborad

### DIFF
--- a/frontend/src/features/admin/ui/AdminScreen.js
+++ b/frontend/src/features/admin/ui/AdminScreen.js
@@ -14,6 +14,36 @@ export default function AdminScreen() {
     const [loading, setLoading] = useState(true);
     const [showLogoutModal, setShowLogoutModal] = useState(false);
 
+    const getCollectionCount = (payload) => {
+        let data = payload;
+
+        if (typeof data === 'string') {
+            try {
+                data = JSON.parse(data);
+            } catch {
+                return 0;
+            }
+        }
+
+        if (Array.isArray(data)) {
+            return data.length;
+        }
+
+        if (data && typeof data === 'object') {
+            if (Array.isArray(data.content)) return data.content.length;
+            if (Array.isArray(data.items)) return data.items.length;
+            if (Array.isArray(data.results)) return data.results.length;
+
+            const totalElements = Number(data.totalElements);
+            if (Number.isFinite(totalElements)) return totalElements;
+
+            const count = Number(data.count);
+            if (Number.isFinite(count)) return count;
+        }
+
+        return 0;
+    };
+
     useEffect(() => {
         fetchDashboardData();
     }, []);
@@ -28,9 +58,9 @@ export default function AdminScreen() {
         ])
             .then(([usersRes, questionsRes, answersRes]) => {
                 setStats({
-                    users: usersRes.data?.length || 0,
-                    questions: questionsRes.data?.length || 0,
-                    answers: answersRes.data?.length || 0,
+                    users: getCollectionCount(usersRes.data),
+                    questions: getCollectionCount(questionsRes.data),
+                    answers: getCollectionCount(answersRes.data),
                 });
             })
             .catch((error) => {


### PR DESCRIPTION
The dashboard calculates users using data.length directly on /api/v1/users, without normalizing the payload.The user list on another screen does parse string responses, but the dashboard does not.There are no custom JSON converters or stats endpoints in the current backend.
CHANGES:
I added a local function, `getCollectionCount`, which normalizes the payload (JSON string, array, content/items/results, totalElements/count).
I replaced the stat calculations for `users/questions/answers` with that function.

NOOOO VIBE CODING