### PR TITLE
fix: prevent duplicate question locations

### DIFF
--- a/frontend/src/features/profile/EditProfileScreen.js
+++ b/frontend/src/features/profile/EditProfileScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
     View,
     Text,
@@ -12,6 +12,7 @@ import {
     Image,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
 import * as ImagePicker from 'expo-image-picker';
 import { useAuth } from '../../app/providers/AuthProvider';
 import apiClient from '../../shared/services/http/apiClient';
@@ -109,27 +110,33 @@ export default function EditProfileScreen({ navigation }) {
         if (shouldGoBack) { navigation.goBack(); }
     };
 
-    useEffect(() => {
-        if (!userId) { setLoading(false); return; }
-        const loadProfile = async () => {
-            try {
-                const res = await apiClient.get(`/api/v1/users/${userId}`);
-                const currentUser = res.data;
-                setOriginalUser(currentUser);
-                setForm({
-                    email: currentUser?.email || '',
-                    userName: currentUser?.userName || '',
-                    firstName: currentUser?.firstName || '',
-                    lastName: currentUser?.lastName || '',
-                    bio: currentUser?.bio || '',
-                    profilePictureUrl: currentUser?.profilePictureUrl || '',
-                });
-            } catch (error) {
-                showFeedback('Error', 'Your data could not be loaded.', 'error');
-            } finally { setLoading(false); }
-        };
-        loadProfile();
-    }, [userId]);
+    useFocusEffect(
+        useCallback(() => {
+            if (!userId) { setLoading(false); return; }
+            let cancelled = false;
+            const loadProfile = async () => {
+                setLoading(true);
+                try {
+                    const res = await apiClient.get(`/api/v1/users/${userId}`);
+                    if (cancelled) return;
+                    const currentUser = res.data;
+                    setOriginalUser(currentUser);
+                    setForm({
+                        email: currentUser?.email || '',
+                        userName: currentUser?.userName || '',
+                        firstName: currentUser?.firstName || '',
+                        lastName: currentUser?.lastName || '',
+                        bio: currentUser?.bio || '',
+                        profilePictureUrl: currentUser?.profilePictureUrl || '',
+                    });
+                } catch (error) {
+                    if (!cancelled) showFeedback('Error', 'Your data could not be loaded.', 'error');
+                } finally { if (!cancelled) setLoading(false); }
+            };
+            loadProfile();
+            return () => { cancelled = true; };
+        }, [userId])
+    );
 
     const updateField = (field, value) => {
         setForm(prev => ({ ...prev, [field]: value }));

--- a/src/main/java/com/streetask/app/coins/StreetCoinPurchaseService.java
+++ b/src/main/java/com/streetask/app/coins/StreetCoinPurchaseService.java
@@ -94,6 +94,7 @@ public class StreetCoinPurchaseService {
 
         return coinTransactionRepository.findByUserIdOrderByCreatedAtDesc(currentUser.getId())
                 .stream()
+                .filter(tx -> tx.getStatus() != CoinTransactionStatus.PENDING)
                 .map(this::toTransactionResponse)
                 .toList();
     }

--- a/src/main/java/com/streetask/app/question/QuestionRepository.java
+++ b/src/main/java/com/streetask/app/question/QuestionRepository.java
@@ -29,4 +29,6 @@ public interface QuestionRepository extends CrudRepository<Question, UUID> {
 
 	long countByCreatorId(UUID creatorId);
 
+	boolean existsByLocationLatitudeAndLocationLongitude(Double latitude, Double longitude);
+
 }

--- a/src/main/java/com/streetask/app/question/QuestionService.java
+++ b/src/main/java/com/streetask/app/question/QuestionService.java
@@ -151,6 +151,21 @@ public class QuestionService {
 			}
 		}
 		question.setCreator(authenticatedUser);
+
+		if (question.getLocation() != null) {
+			double lat = question.getLocation().getLatitude();
+			double lng = question.getLocation().getLongitude();
+
+			while (existsSameLocation(lat, lng)) {
+				double[] newCoords = applyOffset(lat, lng);
+				lat = newCoords[0];
+				lng = newCoords[1];
+			}
+
+			question.getLocation().setLatitude(lat);
+			question.getLocation().setLongitude(lng);
+		}
+
 		// Event questions are scoped to the event itself, not a geographic radius.
 		// Setting radiusKm to null disables the geo restriction check when answering.
 		question.setRadiusKm(eventId != null ? null : resolveRadiusKm(question.getRadiusKm(), isPremium));
@@ -335,6 +350,27 @@ public class QuestionService {
 			throw new UpperPlanFeatureException(
 					"You must confirm spending 1 StreetCoin before creating an extra question.");
 		}
+	}
+
+	// Check if a question already exists with that exact location.
+	private boolean existsSameLocation(double lat, double lng) {
+		return StreamSupport.stream(questionRepository.findAll().spliterator(), false)
+				.anyMatch(q -> {
+					if (q.getLocation() == null)
+						return false;
+					return q.getLocation().getLatitude() == lat
+							&& q.getLocation().getLongitude() == lng;
+				});
+	}
+
+	// Apply small displacement (~2 meters)
+	private double[] applyOffset(double lat, double lng) {
+		double offset = 0.00002; // ≈ 2 metros
+
+		double newLat = lat + (Math.random() - 0.5) * offset;
+		double newLng = lng + (Math.random() - 0.5) * offset;
+
+		return new double[] { newLat, newLng };
 	}
 
 	private void spendStreetCoinForExtraQuestion(RegularUser user, Question question, String description) {

--- a/src/main/java/com/streetask/app/question/QuestionService.java
+++ b/src/main/java/com/streetask/app/question/QuestionService.java
@@ -156,10 +156,11 @@ public class QuestionService {
 			double lat = question.getLocation().getLatitude();
 			double lng = question.getLocation().getLongitude();
 
-			while (existsSameLocation(lat, lng)) {
-				double[] newCoords = applyOffset(lat, lng);
-				lat = newCoords[0];
-				lng = newCoords[1];
+			int maxAttempts = 10;
+			for (int i = 0; i < maxAttempts
+					&& questionRepository.existsByLocationLatitudeAndLocationLongitude(lat, lng); i++) {
+				lat = question.getLocation().getLatitude() + (Math.random() - 0.5) * 0.00002;
+				lng = question.getLocation().getLongitude() + (Math.random() - 0.5) * 0.00002;
 			}
 
 			question.getLocation().setLatitude(lat);
@@ -350,27 +351,6 @@ public class QuestionService {
 			throw new UpperPlanFeatureException(
 					"You must confirm spending 1 StreetCoin before creating an extra question.");
 		}
-	}
-
-	// Check if a question already exists with that exact location.
-	private boolean existsSameLocation(double lat, double lng) {
-		return StreamSupport.stream(questionRepository.findAll().spliterator(), false)
-				.anyMatch(q -> {
-					if (q.getLocation() == null)
-						return false;
-					return q.getLocation().getLatitude() == lat
-							&& q.getLocation().getLongitude() == lng;
-				});
-	}
-
-	// Apply small displacement (~2 meters)
-	private double[] applyOffset(double lat, double lng) {
-		double offset = 0.00002; // ≈ 2 metros
-
-		double newLat = lat + (Math.random() - 0.5) * offset;
-		double newLng = lng + (Math.random() - 0.5) * offset;
-
-		return new double[] { newLat, newLng };
 	}
 
 	private void spendStreetCoinForExtraQuestion(RegularUser user, Question question, String description) {


### PR DESCRIPTION
Ensure multiple questions can coexist at the same coordinates by applying a small offset (~2 meters) when identical locations are detected. This avoids overwriting existing questions and improves map visualization.