### PR TITLE
fix: questions on map

### DIFF
--- a/frontend/src/features/home/ui/HomeScreen.js
+++ b/frontend/src/features/home/ui/HomeScreen.js
@@ -264,6 +264,35 @@ export default function HomeScreen({ navigation }) {
     }, [isFocused, loadEvents, loadQuestions, observeNotifications]);
 
     useEffect(() => {
+        if (Platform.OS !== 'web' || typeof window === 'undefined') {
+            return undefined;
+        }
+
+        const handleQuestionCreated = (event) => {
+            const createdQuestion = event?.detail?.question;
+
+            if (createdQuestion?.id) {
+                setQuestions((currentQuestions) => {
+                    const nextQuestions = [
+                        createdQuestion,
+                        ...currentQuestions.filter((question) => question?.id !== createdQuestion.id),
+                    ];
+                    writeCachedArray(STORAGE_KEYS.HOME_QUESTIONS_CACHE, nextQuestions);
+                    return nextQuestions;
+                });
+            }
+
+            loadQuestions();
+            loadEvents();
+        };
+
+        window.addEventListener('streetask:question-created', handleQuestionCreated);
+        return () => {
+            window.removeEventListener('streetask:question-created', handleQuestionCreated);
+        };
+    }, [loadEvents, loadQuestions]);
+
+    useEffect(() => {
         if (!isFocused || Platform.OS !== 'web' || typeof window === 'undefined') {
             return;
         }

--- a/frontend/src/features/questions/ui/CreateQuestionScreen.js
+++ b/frontend/src/features/questions/ui/CreateQuestionScreen.js
@@ -187,6 +187,18 @@ export default function CreateQuestionScreen({ navigation, route }) {
         const response = await apiClient.post('/api/v1/questions', payload);
         console.log('[CreateQuestionScreen] Created question response:', response?.data);
 
+        if (Platform.OS === 'web' && typeof window !== 'undefined') {
+          window.dispatchEvent(
+            new CustomEvent('streetask:question-created', {
+              detail: {
+                questionId: response?.data?.id ?? null,
+                eventId,
+                question: response?.data ?? null,
+              },
+            })
+          );
+        }
+
         if (eventId) {
           const eventQuestionsResponse = await apiClient.get(`/api/v1/events/${eventId}/questions`);
           const eventQuestionsPayload = eventQuestionsResponse?.data;


### PR DESCRIPTION
mplemented a fix so newly created questions appear on the map immediately in production (Render), not only in local flow.

After a question is created, the app now dispatches a web event from CreateQuestionScreen.js:187. The Home screen listens to that event in HomeScreen.js:263, updates the local cache, and reloads questions/events so the marker is rendered right away.