### PR TITLE
fix: add JsonIgnore to prevent circular serialization in questions API

### DIFF
--- a/src/main/java/com/streetask/app/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/streetask/app/configuration/SecurityConfiguration.java
@@ -114,8 +114,8 @@ public class SecurityConfiguration {
 						.requestMatchers("/api/v1/users").hasAuthority(ADMIN)
 
 						// Questions & Answers require auth
-						.requestMatchers("/api/v1/questions", "/api/v1/questions/**").authenticated()
-						.requestMatchers("/api/v1/events", "/api/v1/events/**").authenticated()
+						.requestMatchers("/api/v1/questions/**").authenticated()
+						.requestMatchers("/api/v1/events/**").authenticated()
 						.requestMatchers("/api/v1/answers", "/api/v1/answers/**").authenticated()
 						.requestMatchers("/api/v1/reports/**").authenticated()
 

--- a/src/main/java/com/streetask/app/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/streetask/app/configuration/SecurityConfiguration.java
@@ -114,8 +114,8 @@ public class SecurityConfiguration {
 						.requestMatchers("/api/v1/users").hasAuthority(ADMIN)
 
 						// Questions & Answers require auth
-						.requestMatchers("/api/v1/questions/**").authenticated()
-						.requestMatchers("/api/v1/events/**").authenticated()
+						.requestMatchers("/api/v1/questions", "/api/v1/questions/**").authenticated()
+						.requestMatchers("/api/v1/events", "/api/v1/events/**").authenticated()
 						.requestMatchers("/api/v1/answers", "/api/v1/answers/**").authenticated()
 						.requestMatchers("/api/v1/reports/**").authenticated()
 

--- a/src/main/java/com/streetask/app/user/RegularUser.java
+++ b/src/main/java/com/streetask/app/user/RegularUser.java
@@ -50,15 +50,19 @@ public class RegularUser extends User {
     @OneToMany(mappedBy = "user")
     private List<Answer> answers;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "regularUser")
     private List<EventAttendance> eventAttendances;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user")
     private List<Notification> notifications;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user")
     private List<CoinTransaction> coinTransactions;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "reporter")
     private List<Report> reports;
 


### PR DESCRIPTION
## Summary
- Add `@JsonIgnore` to `eventAttendances`, `notifications`, `coinTransactions` and `reports` in `RegularUser` to prevent circular JSON serialization
- The `/api/v1/questions` endpoint was failing with `Document nesting depth (1001) exceeds the maximum allowed (1000)` because Jackson followed `Question → creator (RegularUser) → eventAttendances → regularUser → eventAttendances → ...` in an infinite loop
- This caused the frontend to receive a truncated/invalid JSON response, making all questions invisible to users

## Test plan
- [ ] Verify `/api/v1/questions` returns valid JSON with all active questions
- [ ] Verify questions from other users are visible on the map
- [ ] Verify profile editing still works correctly
- [ ] Verify event attendance, notifications, coin transactions and reports still work via their own endpoints