### PR TITLE
docs: add demo video link for sprint 3

### DIFF
--- a/docs/Sprint 3/deliverables/demo.md
+++ b/docs/Sprint 3/deliverables/demo.md
@@ -1,0 +1,1 @@
+https://youtu.be/tJebuRr9XOY


### PR DESCRIPTION
Include the YouTube link of the full demo video in the documentation, with timestamps covering all main use cases.