### PR TITLE
fix: validate event creation data

### DIFF
--- a/frontend/src/features/events/ui/ManageEventsScreen.js
+++ b/frontend/src/features/events/ui/ManageEventsScreen.js
@@ -436,11 +436,13 @@ export default function ManageEventsScreen({ navigation }) {
             });
             return;
         }
+        const coordinateAddress = `(${tempLat.toFixed(5)}, ${tempLng.toFixed(5)})`;
 
         setForm((prev) => ({
             ...prev,
             latitude: String(tempLat),
             longitude: String(tempLng),
+            address: prev.address?.trim() || coordinateAddress,
         }));
         setPlace(`(${tempLat.toFixed(5)}, ${tempLng.toFixed(5)})`);
         setPickedLabel('');
@@ -509,8 +511,8 @@ export default function ManageEventsScreen({ navigation }) {
     const submitEditor = async () => {
         const payload = buildPayload(form);
 
-        if (!payload.title || !payload.description) {
-            Alert.alert('Required fields', 'Title and description are required.');
+        if (!payload.title || !payload.description || !payload.address) {
+            Alert.alert('Required fields', 'Title, description and address are required.');
             return;
         }
 
@@ -559,10 +561,16 @@ export default function ManageEventsScreen({ navigation }) {
             await loadMyEvents();
         } catch (error) {
             console.error('Error saving event:', error);
+
+            const errorMessage =
+                error?.response?.data?.message ||
+                error?.response?.data?.error ||
+                'Could not save the event. Please review the data.';
+
             Toast.show({
                 type: 'error',
                 text1: 'Error',
-                text2: 'Could not save the event. Please review the data.',
+                text2: errorMessage,
                 position: 'top',
             });
         } finally {
@@ -938,7 +946,7 @@ export default function ManageEventsScreen({ navigation }) {
 
                             <TextInput
                                 style={styles.input}
-                                placeholder="Address"
+                                placeholder="Address *"
                                 value={form.address}
                                 onChangeText={(value) => setForm((prev) => ({ ...prev, address: value }))}
                             />

--- a/src/main/java/com/streetask/app/event/EventRepository.java
+++ b/src/main/java/com/streetask/app/event/EventRepository.java
@@ -7,18 +7,22 @@ import com.streetask.app.model.enums.EventCategory;
 import java.time.LocalDateTime;
 import java.util.List;
 
-
-
 public interface EventRepository extends CrudRepository<Event, UUID> {
-	Iterable<Event> findByActive(Boolean active);
-	Iterable<Event> findByCategory(EventCategory category);
-	Iterable<Event> findByActiveAndCategory(Boolean active, EventCategory category);
-	Iterable<Event> findByCreatorId(UUID creatorId);
-	Iterable<Event> findByCreatorIdAndActive(UUID creatorId, Boolean active);
-	List<Event> findByActiveTrueAndEndsAtLessThanEqual(LocalDateTime now);
-	long countByCreatorId(UUID creatorId);
+    Iterable<Event> findByActive(Boolean active);
+
+    Iterable<Event> findByCategory(EventCategory category);
+
+    Iterable<Event> findByActiveAndCategory(Boolean active, EventCategory category);
+
+    Iterable<Event> findByCreatorId(UUID creatorId);
+
+    Iterable<Event> findByCreatorIdAndActive(UUID creatorId, Boolean active);
+
+    List<Event> findByActiveTrueAndEndsAtLessThanEqual(LocalDateTime now);
+
+    long countByCreatorId(UUID creatorId);
+
+    boolean existsByTitleIgnoreCase(String title);
+
+    boolean existsByTitleIgnoreCaseAndIdNot(String title, UUID id);
 }
-
-
-
-

--- a/src/main/java/com/streetask/app/event/EventService.java
+++ b/src/main/java/com/streetask/app/event/EventService.java
@@ -36,6 +36,24 @@ public class EventService {
     private final UserRepository userRepository;
     private final BusinessPremiumAccessGuard businessPremiumAccessGuard;
 
+    private void validateEvent(Event event, UUID eventIdToIgnore) {
+        if (event.getTitle() == null || event.getTitle().isBlank()) {
+            throw new IllegalArgumentException("Event title is required");
+        }
+
+        if (event.getAddress() == null || event.getAddress().isBlank()) {
+            throw new IllegalArgumentException("Event address is required");
+        }
+
+        boolean duplicatedTitle = eventIdToIgnore == null
+                ? eventRepository.existsByTitleIgnoreCase(event.getTitle().trim())
+                : eventRepository.existsByTitleIgnoreCaseAndIdNot(event.getTitle().trim(), eventIdToIgnore);
+
+        if (duplicatedTitle) {
+            throw new IllegalArgumentException("An event with this title already exists");
+        }
+    }
+
     @Autowired
     public EventService(EventRepository eventRepository, EventAttendanceRepository eventAttendanceRepository,
             UserRepository userRepository, BusinessPremiumAccessGuard businessPremiumAccessGuard) {
@@ -83,6 +101,9 @@ public class EventService {
     public Event saveEvent(@Valid Event event) {
         BusinessAccount creator = getAuthenticatedBusinessUser();
         businessPremiumAccessGuard.requireVerified(creator);
+
+        validateEvent(event, null);
+
         event.setCreator(creator);
         applyDefaultsOnCreate(event);
         eventRepository.save(event);
@@ -99,6 +120,8 @@ public class EventService {
         if (!authenticatedBusiness.getId().equals(toUpdate.getCreator().getId())) {
             throw new ResourceNotOwnedException(toUpdate);
         }
+
+        validateEvent(event, idToUpdate);
 
         BeanUtils.copyProperties(event, toUpdate, "id", "creator", "createdAt", "updatedAt", "attendeeCount",
                 "questions", "attendances");

--- a/src/test/java/com/streetask/app/event/EventRestControllerTest.java
+++ b/src/test/java/com/streetask/app/event/EventRestControllerTest.java
@@ -427,6 +427,7 @@ class EventRestControllerTest {
         Map<String, Object> payload = new HashMap<>();
         payload.put("title", "Updated Event Title");
         payload.put("description", "Updated Event Description");
+        payload.put("address", "Updated event address");
         payload.put("active", false);
 
         mockMvc.perform(put("/api/v1/events/{eventId}", event1.getId())
@@ -437,6 +438,7 @@ class EventRestControllerTest {
                 .andExpect(jsonPath("$.id").value(event1.getId().toString()))
                 .andExpect(jsonPath("$.title").value("Updated Event Title"))
                 .andExpect(jsonPath("$.description").value("Updated Event Description"))
+                .andExpect(jsonPath("$.address").value("Updated event address"))
                 .andExpect(jsonPath("$.active").value(false));
     }
 

--- a/src/test/java/com/streetask/app/event/EventServiceTest.java
+++ b/src/test/java/com/streetask/app/event/EventServiceTest.java
@@ -86,6 +86,7 @@ class EventServiceTest {
         Event event = new Event();
         event.setTitle("Service Event");
         event.setDescription("Created from service test");
+        event.setAddress("Test address");
 
         Event saved = eventService.saveEvent(event);
 
@@ -230,10 +231,12 @@ class EventServiceTest {
         existing.setCreator(owner);
         existing.setTitle("Original Title");
         existing.setDescription("Original Description");
+        existing.setAddress("Original address");
 
         Event incoming = new Event();
         incoming.setTitle("Updated Title");
         incoming.setDescription("Updated Description");
+        incoming.setAddress("Updated address");
         incoming.setActive(false);
 
         authenticateAs(owner.getEmail());
@@ -246,6 +249,7 @@ class EventServiceTest {
         assertEquals(eventId, updated.getId());
         assertEquals("Updated Title", updated.getTitle());
         assertEquals("Updated Description", updated.getDescription());
+        assertEquals("Updated address", updated.getAddress());
         assertFalse(updated.getActive());
         assertEquals(owner.getId(), updated.getCreator().getId());
         verify(eventRepository).save(existing);


### PR DESCRIPTION
Prevent events from being created or updated without a title, description, or address. Add duplicate title validation in the backend and improve the frontend event form to handle map-selected locations and display API errors.