### PR TITLE
feat: business users map view with no questions

### DIFF
--- a/frontend/src/features/home/ui/HomeScreen.js
+++ b/frontend/src/features/home/ui/HomeScreen.js
@@ -67,7 +67,7 @@ export default function HomeScreen({ navigation }) {
 
     const [questions, setQuestions] = useState([]);
     const [events, setEvents] = useState([]);
-    const [showQuestions, setShowQuestions] = useState(true);
+    const [showQuestions, setShowQuestions] = useState(!isBusinessUser);
     const [currentLocation, setCurrentLocation] = useState(null);
     const [isPremium, setIsPremium] = useState(false);
     const [sidebarTab, setSidebarTab] = useState('QUESTIONS');
@@ -748,15 +748,17 @@ export default function HomeScreen({ navigation }) {
                         }}
                     />
 
-                    <View style={[styles.footer, isNarrow && { paddingHorizontal: 14 }]}>
-                        <Text style={styles.toggleLabel}>Show Questions</Text>
-                        <Switch
-                            value={showQuestions}
-                            onValueChange={setShowQuestions}
-                            trackColor={{ false: '#d1d5db', true: '#a52019' }}
-                            thumbColor="#fff"
-                        />
-                    </View>
+                    {!isBusinessUser && (
+                        <View style={[styles.footer, isNarrow && { paddingHorizontal: 14 }]}>
+                            <Text style={styles.toggleLabel}>Show Questions</Text>
+                            <Switch
+                                value={showQuestions}
+                                onValueChange={setShowQuestions}
+                                trackColor={{ false: '#d1d5db', true: '#a52019' }}
+                                thumbColor="#fff"
+                            />
+                        </View>
+                    )}
                     {hasLocationPermission && (
                         <>
                             {isBusiness && (


### PR DESCRIPTION
Changed how the showquestion boolean work and hid the toggle for business users. Now it is set on false by default for business and true for normal users

 "const [showQuestions, setShowQuestions] = useState(!isBusinessUser);"


PS: Couldn't test this properly since i coulnt't acces a business account in my local environment