### PR TITLE
fix: voting at bussines account

### DIFF
--- a/src/main/java/com/streetask/app/answer/AnswerService.java
+++ b/src/main/java/com/streetask/app/answer/AnswerService.java
@@ -173,10 +173,12 @@ public class AnswerService {
     @Transactional
     public Answer updateVotes(UUID answerId, UUID userId, VoteType voteType) {
         Answer answer = findAnswer(answerId);
-        RegularUser answerOwner = asRegularUser(answer.getUser());
+        normalizeVoteCounters(answer);
+        User answerOwner = answer.getUser();
         if (answerOwner != null && answerOwner.getId() != null && answerOwner.getId().equals(userId)) {
             throw new IllegalArgumentException("Users cannot like or dislike their own answers");
         }
+        RegularUser regularOwner = asRegularUser(answerOwner);
 
         User voter = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
@@ -196,13 +198,13 @@ public class AnswerService {
             if (voteType == VoteType.LIKE) {
                 answer.setUpvotes(answer.getUpvotes() + 1);
                 answer.setDownvotes(Math.max(0, answer.getDownvotes() - 1));
-                decrementDislikes(answerOwner);
-                incrementLikes(answerOwner);
+                decrementDislikes(regularOwner);
+                incrementLikes(regularOwner);
             } else {
                 answer.setDownvotes(answer.getDownvotes() + 1);
                 answer.setUpvotes(Math.max(0, answer.getUpvotes() - 1));
-                decrementLikes(answerOwner);
-                incrementDislikes(answerOwner);
+                decrementLikes(regularOwner);
+                incrementDislikes(regularOwner);
             }
             existing.setVoteType(voteType);
             existing.setVotedAt(LocalDateTime.now());
@@ -216,10 +218,10 @@ public class AnswerService {
             answerVoteRepository.save(vote);
             if (voteType == VoteType.LIKE) {
                 answer.setUpvotes(answer.getUpvotes() + 1);
-                incrementLikes(answerOwner);
+                incrementLikes(regularOwner);
             } else {
                 answer.setDownvotes(answer.getDownvotes() + 1);
-                incrementDislikes(answerOwner);
+                incrementDislikes(regularOwner);
             }
         }
 
@@ -230,15 +232,17 @@ public class AnswerService {
     @Transactional
     public Answer removeVote(UUID answerId, UUID userId) {
         Answer answer = findAnswer(answerId);
-        RegularUser answerOwner = asRegularUser(answer.getUser());
+        normalizeVoteCounters(answer);
+        User answerOwner = answer.getUser();
+        RegularUser regularOwner = asRegularUser(answerOwner);
         AnswerVote existing = answerVoteRepository.findByUserIdAndAnswerId(userId, answerId)
                 .orElseThrow(() -> new IllegalArgumentException("No vote found for this user on this answer"));
         if (existing.getVoteType() == VoteType.LIKE) {
             answer.setUpvotes(Math.max(0, answer.getUpvotes() - 1));
-            decrementLikes(answerOwner);
+            decrementLikes(regularOwner);
         } else {
             answer.setDownvotes(Math.max(0, answer.getDownvotes() - 1));
-            decrementDislikes(answerOwner);
+            decrementDislikes(regularOwner);
         }
         answerVoteRepository.delete(existing);
         Answer savedAnswer = answerRepository.save(answer);
@@ -342,10 +346,21 @@ public class AnswerService {
         }
     }
 
+    private void normalizeVoteCounters(Answer answer) {
+        if (answer.getUpvotes() == null) {
+            answer.setUpvotes(0);
+        }
+        if (answer.getDownvotes() == null) {
+            answer.setDownvotes(0);
+        }
+    }
+
     private Answer reconcileAnswerCoins(Answer answer) {
         if (answer.getUser() == null) {
             return answer;
         }
+
+        normalizeVoteCounters(answer);
 
         int targetCoins = calculateTargetCoinsEarned(answer);
         int currentCoins = answer.getCoinsEarned() == null ? 0 : answer.getCoinsEarned();
@@ -387,6 +402,8 @@ public class AnswerService {
     }
 
     private int calculateTargetCoinsEarned(Answer answer) {
+        normalizeVoteCounters(answer);
+
         if (isSelfAnswer(answer)) {
             return 0;
         }
@@ -397,8 +414,8 @@ public class AnswerService {
             return 0;
         }
 
-        int likes = answer.getUpvotes() == null ? 0 : answer.getUpvotes();
-        int dislikes = answer.getDownvotes() == null ? 0 : answer.getDownvotes();
+        int likes = answer.getUpvotes();
+        int dislikes = answer.getDownvotes();
 
         if (likes > dislikes) {
             return ANSWER_BASE_REWARD + ANSWER_POSITIVE_VOTE_BONUS;

--- a/src/main/java/com/streetask/app/business/BusinessAccount.java
+++ b/src/main/java/com/streetask/app/business/BusinessAccount.java
@@ -49,6 +49,10 @@ public class BusinessAccount extends User {
 
     private Float rating = 0.0f;
 
+    private Integer totalLikesReceived;
+
+    private Integer totalDislikesReceived;
+
     private LocalDateTime verifiedAt;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/streetask/app/user/UserService.java
+++ b/src/main/java/com/streetask/app/user/UserService.java
@@ -317,6 +317,10 @@ public class UserService {
             likesCount = regularUser.getTotalLikesReceived() == null ? 0 : regularUser.getTotalLikesReceived();
             dislikesCount = regularUser.getTotalDislikesReceived() == null ? 0 : regularUser.getTotalDislikesReceived();
             coinBalance = regularUser.getCoinBalance() == null ? 0 : regularUser.getCoinBalance();
+        } else if (user instanceof BusinessAccount businessAccount) {
+            int[] voteCounts = resolveAnswerVoteCounts(userId);
+            likesCount = voteCounts[0];
+            dislikesCount = voteCounts[1];
         }
 
         Map<String, Object> stats = new HashMap<>();
@@ -349,6 +353,17 @@ public class UserService {
         stats.put("rating", rating);
 
         return stats;
+    }
+
+    private int[] resolveAnswerVoteCounts(UUID userId) {
+        List<Object[]> aggregates = answerRepository.aggregateVotesByUserIds(List.of(userId));
+        if (aggregates.isEmpty()) {
+            return new int[] { 0, 0 };
+        }
+        Object[] row = aggregates.get(0);
+        int likes = ((Number) row[1]).intValue();
+        int dislikes = ((Number) row[2]).intValue();
+        return new int[] { likes, dislikes };
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/db/migration/V18__normalize_answer_vote_counters.sql
+++ b/src/main/resources/db/migration/V18__normalize_answer_vote_counters.sql
@@ -1,0 +1,8 @@
+-- Normalize answer vote counters so legacy rows and business answers persist likes/dislikes correctly.
+UPDATE answers
+SET upvotes = COALESCE(upvotes, 0),
+    downvotes = COALESCE(downvotes, 0);
+
+ALTER TABLE answers
+    MODIFY upvotes int NOT NULL DEFAULT 0,
+    MODIFY downvotes int NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V19__fix_answer_votes_user_fk_to_appusers.sql
+++ b/src/main/resources/db/migration/V19__fix_answer_votes_user_fk_to_appusers.sql
@@ -1,0 +1,8 @@
+-- Fix answer_votes.user_id FK: it was pointing to regular_users, which prevented business accounts from voting.
+
+ALTER TABLE answer_votes
+    DROP FOREIGN KEY FKeovt71gx6r5ts4eyxde7eguqq;
+
+ALTER TABLE answer_votes
+    ADD CONSTRAINT FKeovt71gx6r5ts4eyxde7eguqq
+        FOREIGN KEY (user_id) REFERENCES appusers (id);

--- a/src/main/resources/db/migration/V20__add_vote_counters_to_business_accounts.sql
+++ b/src/main/resources/db/migration/V20__add_vote_counters_to_business_accounts.sql
@@ -1,0 +1,17 @@
+-- Add vote tracking columns to business_accounts
+ALTER TABLE `business_accounts`
+ADD COLUMN `total_likes_received` INT NOT NULL DEFAULT 0,
+ADD COLUMN `total_dislikes_received` INT NOT NULL DEFAULT 0;
+
+-- Update existing business accounts with vote counts from their answers
+UPDATE `business_accounts` ba
+SET ba.`total_likes_received` = COALESCE((
+    SELECT SUM(a.`upvotes`)
+    FROM `answers` a
+    WHERE a.`user_id` = ba.`id`
+), 0),
+ba.`total_dislikes_received` = COALESCE((
+    SELECT SUM(a.`downvotes`)
+    FROM `answers` a
+    WHERE a.`user_id` = ba.`id`
+), 0);

--- a/src/test/java/com/streetask/app/answer/AnswerServiceTest.java
+++ b/src/test/java/com/streetask/app/answer/AnswerServiceTest.java
@@ -680,6 +680,35 @@ class AnswerServiceTest {
     }
 
     @Test
+    void testUpdateVotesBusinessAnswerWithNullCountersPersistsLike() {
+        BusinessAccount businessOwner = new BusinessAccount();
+        businessOwner.setId(UUID.randomUUID());
+        businessOwner.setEmail("owner@streetask.com");
+        businessOwner.setUserName("bizowner");
+
+        BusinessAccount businessVoter = new BusinessAccount();
+        businessVoter.setId(userId);
+        businessVoter.setEmail("voter@streetask.com");
+        businessVoter.setUserName("bizvoter");
+
+        answer.setUser(businessOwner);
+        answer.setUpvotes(null);
+        answer.setDownvotes(null);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(businessVoter));
+        when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
+        when(answerVoteRepository.findByUserIdAndAnswerId(userId, answerId)).thenReturn(Optional.empty());
+        when(answerRepository.save(answer)).thenReturn(answer);
+
+        Answer result = answerService.updateVotes(answerId, userId, VoteType.LIKE);
+
+        assertEquals(1, result.getUpvotes());
+        assertEquals(0, result.getDownvotes());
+        verify(answerVoteRepository, times(1)).save(any(AnswerVote.class));
+        verify(answerRepository, atLeastOnce()).save(answer);
+    }
+
+    @Test
     void testUpdateVotesSameVoteIsNoOp() {
         AnswerVote existing = new AnswerVote();
         existing.setVoteType(VoteType.LIKE);

--- a/src/test/java/com/streetask/app/answer/AnswerVoteRepositoryTest.java
+++ b/src/test/java/com/streetask/app/answer/AnswerVoteRepositoryTest.java
@@ -1,0 +1,121 @@
+package com.streetask.app.answer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.streetask.app.business.BusinessAccount;
+import com.streetask.app.model.Answer;
+import com.streetask.app.model.AnswerVote;
+import com.streetask.app.model.GeoPoint;
+import com.streetask.app.model.Question;
+import com.streetask.app.model.enums.VoteType;
+import com.streetask.app.user.Authorities;
+import com.streetask.app.user.RegularUser;
+
+@DataJpaTest
+class AnswerVoteRepositoryTest {
+
+    private static final UUID REGULAR_AUTHORITY_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID BUSINESS_AUTHORITY_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private AnswerVoteRepository answerVoteRepository;
+
+    private BusinessAccount businessVoter;
+    private Answer answer;
+
+    @BeforeEach
+    void setUp() {
+        Authorities regularAuthority = entityManager.find(Authorities.class, REGULAR_AUTHORITY_ID);
+        Authorities businessAuthority = entityManager.find(Authorities.class, BUSINESS_AUTHORITY_ID);
+
+        RegularUser questionCreator = new RegularUser();
+        questionCreator.setEmail("creator@test.com");
+        questionCreator.setUserName("creator");
+        questionCreator.setFirstName("Question");
+        questionCreator.setLastName("Creator");
+        questionCreator.setPassword("secret");
+        questionCreator.setAuthority(regularAuthority);
+        questionCreator.setActive(true);
+        questionCreator = entityManager.persistAndFlush(questionCreator);
+
+        Question question = new Question();
+        question.setCreator(questionCreator);
+        question.setTitle("Question title");
+        question.setContent("Question content");
+        question.setActive(true);
+        question.setCreatedAt(Instant.now());
+        question = entityManager.persistAndFlush(question);
+
+        RegularUser answerAuthor = new RegularUser();
+        answerAuthor.setEmail("author@test.com");
+        answerAuthor.setUserName("author");
+        answerAuthor.setFirstName("Answer");
+        answerAuthor.setLastName("Author");
+        answerAuthor.setPassword("secret");
+        answerAuthor.setAuthority(regularAuthority);
+        answerAuthor.setActive(true);
+        answerAuthor = entityManager.persistAndFlush(answerAuthor);
+
+        answer = new Answer();
+        answer.setQuestion(question);
+        answer.setUser(answerAuthor);
+        answer.setContent("This is a persisted answer");
+        answer.setCreatedAt(null);
+        answer.setUpvotes(0);
+        answer.setDownvotes(0);
+        answer.setCoinsEarned(0);
+        answer.setRewardClaimed(false);
+        answer.setUserLocation(new GeoPoint());
+        answer.getUserLocation().setLatitude(40.4168);
+        answer.getUserLocation().setLongitude(-3.7038);
+        answer = entityManager.persistAndFlush(answer);
+
+        businessVoter = new BusinessAccount();
+        businessVoter.setEmail("business-voter@test.com");
+        businessVoter.setUserName("businessvoter");
+        businessVoter.setFirstName("Business");
+        businessVoter.setLastName("Voter");
+        businessVoter.setPassword("secret");
+        businessVoter.setAuthority(businessAuthority);
+        businessVoter.setCompanyName("Business Voter SL");
+        businessVoter.setTaxId("B12345679");
+        businessVoter.setActive(true);
+        businessVoter = entityManager.persistAndFlush(businessVoter);
+
+        entityManager.clear();
+    }
+
+    @Test
+    void saveAndReloadBusinessVote_shouldPersistAgainstAppUsersFk() {
+        Answer reloadedAnswer = entityManager.find(Answer.class, answer.getId());
+        BusinessAccount reloadedBusinessVoter = entityManager.find(BusinessAccount.class, businessVoter.getId());
+
+        AnswerVote vote = new AnswerVote();
+        vote.setAnswer(reloadedAnswer);
+        vote.setUser(reloadedBusinessVoter);
+        vote.setVoteType(VoteType.LIKE);
+        vote.setVotedAt(java.time.LocalDateTime.now());
+
+        AnswerVote savedVote = answerVoteRepository.save(vote);
+        entityManager.flush();
+        entityManager.clear();
+
+        AnswerVote foundVote = answerVoteRepository.findById(savedVote.getId()).orElseThrow();
+
+        assertThat(foundVote.getUser()).isInstanceOf(BusinessAccount.class);
+        assertThat(foundVote.getVoteType()).isEqualTo(VoteType.LIKE);
+        assertThat(answerVoteRepository.findByUserIdAndAnswerId(businessVoter.getId(), answer.getId())).isPresent();
+    }
+}

--- a/src/test/java/com/streetask/app/user/UserServiceTest.java
+++ b/src/test/java/com/streetask/app/user/UserServiceTest.java
@@ -584,6 +584,33 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("getUserStats should return business vote counters and rating")
+    void getUserStats_shouldReturnBusinessVoteCountersAndRating() {
+        BusinessAccount businessAccount = new BusinessAccount();
+        businessAccount.setId(testUserId);
+        businessAccount.setEmail(TEST_EMAIL);
+        businessAccount.setUserName(TEST_USERNAME);
+        Authorities businessAuthority = new Authorities();
+        businessAuthority.setAuthority("BUSINESS");
+        businessAccount.setAuthority(businessAuthority);
+        businessAccount.setCompanyName("Test Company");
+        businessAccount.setTaxId("12345678X");
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(businessAccount));
+        when(questionRepository.countByCreatorId(testUserId)).thenReturn(1L);
+        when(answerRepository.countByUserId(testUserId)).thenReturn(4L);
+        when(answerRepository.aggregateVotesByUserIds(eq(List.of(testUserId))))
+            .thenReturn(Collections.singletonList(new Object[] { testUserId, 6L, 2L }));
+
+        Map<String, Object> stats = userService.getUserStats(testUserId);
+
+        assertNotNull(stats);
+        assertEquals(6, stats.get("likesCount"));
+        assertEquals(2, stats.get("dislikesCount"));
+        assertEquals(3.8, stats.get("rating"));
+        assertEquals(0, stats.get("coinBalance"));
+    }
+
+    @Test
     @DisplayName("getUserStats should return correct role for ADMIN user")
     void getUserStats_shouldReturnAdminRole() {
         User user = createTestUserWithAuthority(testUserId, TEST_EMAIL, TEST_USERNAME, "ADMIN");


### PR DESCRIPTION
Updated answer vote handling so business users can vote and their votes are persisted properly, and the answer owner’s vote counters are kept consistent with like/dislike changes. Extended stats logic to include business accounts so the profile Rated with value is computed from actual answer vote aggregates, not just regular-user counters. Added/adjusted unit tests to cover business vote persistence and business stats/rating calculation. Cleaned redundant logic in the vote flow so only the necessary counter updates remain.