### PR TITLE
fix: change window dispatchEvent for navigation and catch cache errors

### DIFF
--- a/frontend/src/features/home/ui/HomeScreen.js
+++ b/frontend/src/features/home/ui/HomeScreen.js
@@ -58,7 +58,7 @@ const writeCachedArray = (key, value) => {
     window.localStorage.setItem(key, JSON.stringify(value));
 };
 
-export default function HomeScreen({ navigation }) {
+export default function HomeScreen({ navigation, route }) {
     const { logout, token, user } = useAuth();
     const { ephemeralNotification, observeNotifications } = useNotifications();
     const { width } = useWindowDimensions();
@@ -265,12 +265,8 @@ export default function HomeScreen({ navigation }) {
     }, [isFocused, loadEvents, loadQuestions, observeNotifications]);
 
     useEffect(() => {
-        if (Platform.OS !== 'web' || typeof window === 'undefined') {
-            return undefined;
-        }
-
-        const handleQuestionCreated = (event) => {
-            const createdQuestion = event?.detail?.question;
+        if (route.params?.refreshNonce) {
+            const createdQuestion = route.params?.newQuestion;
 
             if (createdQuestion?.id) {
                 setQuestions((currentQuestions) => {
@@ -278,20 +274,21 @@ export default function HomeScreen({ navigation }) {
                         createdQuestion,
                         ...currentQuestions.filter((question) => question?.id !== createdQuestion.id),
                     ];
-                    writeCachedArray(STORAGE_KEYS.HOME_QUESTIONS_CACHE, nextQuestions);
+                    try {
+                        writeCachedArray(STORAGE_KEYS.HOME_QUESTIONS_CACHE, nextQuestions);
+                    } catch (error) {
+                        console.warn("Cache full, ignoring saved data to prevent app crashes");
+                    }
                     return nextQuestions;
                 });
             }
 
             loadQuestions();
             loadEvents();
-        };
 
-        window.addEventListener('streetask:question-created', handleQuestionCreated);
-        return () => {
-            window.removeEventListener('streetask:question-created', handleQuestionCreated);
-        };
-    }, [loadEvents, loadQuestions]);
+            navigation.setParams({ refreshNonce: undefined, newQuestion: undefined });
+        }
+    }, [route.params?.refreshNonce, route.params?.newQuestion, loadQuestions, loadEvents, navigation]);
 
     useEffect(() => {
         if (!isFocused || Platform.OS !== 'web' || typeof window === 'undefined') {

--- a/frontend/src/features/questions/ui/CreateQuestionScreen.js
+++ b/frontend/src/features/questions/ui/CreateQuestionScreen.js
@@ -199,18 +199,6 @@ export default function CreateQuestionScreen({ navigation, route }) {
         const response = await apiClient.post('/api/v1/questions', payload);
         console.log('[CreateQuestionScreen] Created question response:', response?.data);
 
-        if (Platform.OS === 'web' && typeof window !== 'undefined') {
-          window.dispatchEvent(
-            new CustomEvent('streetask:question-created', {
-              detail: {
-                questionId: response?.data?.id ?? null,
-                eventId,
-                question: response?.data ?? null,
-              },
-            })
-          );
-        }
-
         if (eventId) {
           const eventQuestionsResponse = await apiClient.get(`/api/v1/events/${eventId}/questions`);
           const eventQuestionsPayload = eventQuestionsResponse?.data;
@@ -242,8 +230,11 @@ export default function CreateQuestionScreen({ navigation, route }) {
         });
         if (eventId) {
           navigation.navigate({
-            name: 'EventDetails',
-            params: { eventId, refreshNonce: Date.now() },
+            name: 'Home',
+            params: {
+              refreshNonce: Date.now(),
+              newQuestion: response?.data
+            },
             merge: true,
           });
           return;


### PR DESCRIPTION
Removed the web-only `window.dispatchEvent` approach that can cause fatal errors in the Expo production build. Added try/catch block to prevent app crashes during AsyncStorage operations.
Closes #647 